### PR TITLE
依赖版本号和统计数据修正

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
+++ b/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
@@ -141,14 +141,20 @@ public abstract class Channel {
 
     public Record pull() {
         Record record = this.doPull();
-        this.statPull(1L, record.getByteSize());
+		if (!(record instanceof TerminateRecord)) {
+			this.statPull(1L, record.getByteSize());
+		}
         return record;
     }
 
     public void pullAll(final Collection<Record> rs) {
         Validate.notNull(rs);
         this.doPullAll(rs);
-        this.statPull(rs.size(), this.getByteSize(rs));
+        if(rs.contains(TerminateRecord.get())){
+        		this.statPull(rs.size() - 1, this.getByteSize(rs));
+        }else{
+        		this.statPull(rs.size(), this.getByteSize(rs));
+        }
     }
 
     protected abstract void doPush(Record r);

--- a/otsstreamreader/pom.xml
+++ b/otsstreamreader/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>tablestore-streamclient</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
1、将tablestore-streamclient依赖的版本号由1.0.0-SNAPSHOT修正为1.0.0

2、TerminateRecord相当于一个结束标志，不应该算在writeReceivedRecords内，  …
不然writeReceivedRecords会比readSucceedRecords大1