### PR TITLE
hdfs String Value \n replaceAll ' '

### DIFF
--- a/hdfswriter/src/main/java/com/alibaba/datax/plugin/writer/hdfswriter/HdfsHelper.java
+++ b/hdfswriter/src/main/java/com/alibaba/datax/plugin/writer/hdfswriter/HdfsHelper.java
@@ -518,7 +518,7 @@ public  class HdfsHelper {
                             case STRING:
                             case VARCHAR:
                             case CHAR:
-                                recordList.add(column.asString());
+                                recordList.add(column.asString().replaceAll("\n"," "));
                                 break;
                             case BOOLEAN:
                                 recordList.add(column.asBoolean());


### PR DESCRIPTION
当hdfs writer 中存在数据为 \n 的情况时，替换为空格，否则会在文本中换行，被hive、impala识别为2条