### PR TITLE
修改hdfswirter.java在获取路径的层级标识符导致的路径错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Datax-logo](https://github.com/alibaba/DataX/blob/master/images/DataX-logo.jpg)
 
-
+afsffsdfs
 
 # DataX
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 afsffsdfs
 
-# DataX
+# DataXfdsfsf
 
 DataX 是阿里巴巴集团内被广泛使用的离线数据同步工具/平台，实现包括 MySQL、Oracle、SqlServer、Postgre、HDFS、Hive、ADS、HBase、TableStore(OTS)、MaxCompute(ODPS)、DRDS 等各种异构数据源之间高效的数据同步功能。
 

--- a/hdfswriter/src/main/java/com/alibaba/datax/plugin/writer/hdfswriter/HdfsWriter.java
+++ b/hdfswriter/src/main/java/com/alibaba/datax/plugin/writer/hdfswriter/HdfsWriter.java
@@ -212,8 +212,18 @@ public class HdfsWriter extends Writer {
             String fileSuffix;
             //临时存放路径
             String storePath =  buildTmpFilePath(this.path);
+            if(storePath != null && storePath.contains("/")){
+            	//由于在window上调试获取的路径为转义字符代表的斜杠
+                //故出现被认为是文件名称的一部分，使得获取父目录存在问题
+                //最终影响到直接删除更高一层的目录，导致Hive数据出现问题。
+            	storePath = storePath.replace('\\', '/');
+            }
             //最终存放路径
             String endStorePath = buildFilePath();
+            if(endStorePath != null && endStorePath.contains("/")){
+            	//storePath.replaceAll("\\", "/");
+            	endStorePath = endStorePath.replace('\\', '/');
+            }
             this.path = endStorePath;
             for (int i = 0; i < mandatoryNumber; i++) {
                 // handle same file name


### PR DESCRIPTION
环境介绍：
1.window10环境下JDK1.8调试状态。
问题介绍：
hdfswriter.java中第214行获取临时数据存放路径后，由于出现反斜杠''，导致路径在获取父目录用于删除临时文件时获取错误的父目录，将‘\’当成了文件名称，而不是目录层级标识，最终错误的删除了我指定的整个目录，同时最终数据因为删除了更上级的父目录，导致传输至最终目的的数据也被删除。
暂时的修改方式是：
判断storePath和endStorePath是否包含'/'，如果包含，则将''替换成/。
经过测试，最终在MAC，Linux，windows测试通过。
String storePath = buildTmpFilePath(this.path); if(storePath != null && storePath.contains("/")){ //由于在window上调试获取的路径为转义字符代表的斜杠，故出现被认为是文件名称的一部分，使得获取父目录存在问题，最终影响到直接删除更高一层的目录，导致Hive数据出现问题。 storePath = storePath.replace('\\', '/'); } //最终存放路径 String endStorePath = buildFilePath(); if(endStorePath != null && endStorePath.contains("/")){ //storePath.replaceAll("\\", "/"); endStorePath = endStorePath.replace('\\', '/'); }