### PR TITLE
为文本写入(如ftpwriter)添加BLOB,BFILE,RAW,LONG RAW类型支持

### DIFF
--- a/ftpreader/doc/ftpreader.md
+++ b/ftpreader/doc/ftpreader.md
@@ -306,6 +306,7 @@ boolean captureRawRecord = true;
 | String   |String|
 | Boolean  |Boolean |
 | Date     |Date |
+| Bytes    |Bytes |
 
 其中：
 
@@ -313,6 +314,8 @@ boolean captureRawRecord = true;
 * 远程FTP文件 Double是指远程FTP文件文本中使用Double的字符串表示形式，例如"3.1415"。
 * 远程FTP文件 Boolean是指远程FTP文件文本中使用Boolean的字符串表示形式，例如"true"、"false"。不区分大小写。
 * 远程FTP文件 Date是指远程FTP文件文本中使用Date的字符串表示形式，例如"2014-12-31"，Date可以指定format格式。
+* 远程FTP文件 Bytes是指远程FTP文件文本中使用Bytes的字符串表示形式，经过BASE64编码，例如"MTIzZmRhZmFm"。
+  针对原数据类型为BLOB,BFILE,RAW,LONG RAW等的数据，读取时需要指定类型为Bytes。
 
 
 ## 4 性能报告

--- a/ftpwriter/doc/ftpwriter.md
+++ b/ftpwriter/doc/ftpwriter.md
@@ -14,7 +14,7 @@ FtpWriter提供了向远程FTP文件写入CSV格式的一个或者多个文件�
 
 FtpWriter实现了从DataX协议转为FTP文件功能，FTP文件本身是无结构化数据存储，FtpWriter如下几个方面约定:
 
-1. 支持且仅支持写入文本类型(不支持BLOB如视频数据)的文件，且要求文本中shema为一张二维表。
+1. 支持且仅支持写入文本类型(支持BLOB如视频数据)的文件，且要求文本中shema为一张二维表。
 
 2. 支持类CSV格式文件，自定义分隔符。
 
@@ -222,6 +222,7 @@ FTP文件本身不提供数据类型，该类型是DataX FtpWriter定义：
 | String   |String -> 字符串序列化表示| 
 | Boolean  |Boolean -> 字符串序列化表示| 
 | Date     |Date -> 字符串序列化表示|
+| Bytes    |Bytes -> 字符串BASE64加密表示|
 
 其中：
 
@@ -229,7 +230,7 @@ FTP文件本身不提供数据类型，该类型是DataX FtpWriter定义：
 * FTP文件 Double是指FTP文件文本中使用Double的字符串表示形式，例如"3.1415"。
 * FTP文件 Boolean是指FTP文件文本中使用Boolean的字符串表示形式，例如"true"、"false"。不区分大小写。
 * FTP文件 Date是指FTP文件文本中使用Date的字符串表示形式，例如"2014-12-31"，Date可以指定format格式。
-
+* FTP文件 Bytes是指FTP文件文本中使用Bytes的字符串表示形式，经过BASE64编码，例如"MTIzZmRhZmFm"。
 
 ## 4 性能报告
 

--- a/ftpwriter/doc/ftpwriter.md
+++ b/ftpwriter/doc/ftpwriter.md
@@ -208,6 +208,15 @@ FtpWriter实现了从DataX协议转为FTP文件功能，FTP文件本身是无结
  	* 必选：否 <br />
  
  	* 默认值：无 <br />
+ 	
+* **forceQualifier**
+       
+    * 描述：强制启用文本限定符 <br />
+    
+    * 必须：否 <br />
+    
+    * 默认值: false <br />
+
 
 ### 3.3 类型转换
 

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.misc.BASE64Decoder;
 
 import java.io.*;
 import java.nio.charset.UnsupportedCharsetException;
@@ -459,6 +460,21 @@ public class UnstructuredStorageReaderUtil {
 										"DATE"));
 							}
 							break;
+						//BYTES类型字段经BASE64解码处理
+						case BYTES:
+							try {
+								if (columnValue == null){
+									columnGenerated = new BytesColumn();
+								}else{
+									BASE64Decoder dec = new BASE64Decoder();
+									columnGenerated = new BytesColumn(dec.decodeBuffer(columnValue));
+								}
+							} catch (Exception e) {
+								throw new IllegalArgumentException(String.format(
+										"类型转换错误, 无法将[%s] 转换为[%s]", columnValue,
+										"BYTES"));
+							}
+							break;
 						default:
 							String errorMessage = String.format(
 									"您配置的列类型暂不支持 : [%s]", columnType);
@@ -506,7 +522,7 @@ public class UnstructuredStorageReaderUtil {
 	}
 
 	private enum Type {
-		STRING, LONG, BOOLEAN, DOUBLE, DATE, ;
+		STRING, LONG, BOOLEAN, DOUBLE, DATE, BYTES, ;
 	}
 
 	/**

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/Constant.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/Constant.java
@@ -16,4 +16,6 @@ public class Constant {
 	public static final Long MAX_FILE_SIZE = 1024 * 1024 * 10 * 10000L;
 	
 	public static final String DEFAULT_SUFFIX = "";
+
+	public static final boolean DEFAULT_FORCE_QUALIFIER = false;
 }

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/Key.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/Key.java
@@ -35,4 +35,7 @@ public class Key {
     
     // writer file type suffix, like .txt  .csv
     public static final String SUFFIX = "suffix";
+
+    // not must, default false
+    public static final String FORCE_QUALIFIER = "forceQualifier";
 }

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/TextCsvWriterManager.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/TextCsvWriterManager.java
@@ -1,15 +1,14 @@
 package com.alibaba.datax.plugin.unstructuredstorage.writer;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.util.List;
-
+import com.csvreader.CsvWriter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.csvreader.CsvWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
 
 public class TextCsvWriterManager {
     public static UnstructuredWriter produceUnstructuredWriter(
@@ -18,7 +17,17 @@ public class TextCsvWriterManager {
         if (Constant.FILE_FORMAT_TEXT.equals(fileFormat)) {
             return new TextWriterImpl(writer, fieldDelimiter);
         } else {
-            return new CsvWriterImpl(writer, fieldDelimiter);
+            return new CsvWriterImpl(writer, fieldDelimiter, Constant.DEFAULT_FORCE_QUALIFIER);
+        }
+    }
+
+    public static UnstructuredWriter produceUnstructuredWriter(
+            String fileFormat, char fieldDelimiter, Writer writer, boolean forceQualifier) {
+        // warn: false means plain text(old way), true means strict csv format
+        if (Constant.FILE_FORMAT_TEXT.equals(fileFormat)) {
+            return new TextWriterImpl(writer, fieldDelimiter);
+        } else {
+            return new CsvWriterImpl(writer, fieldDelimiter, forceQualifier);
         }
     }
 }
@@ -30,13 +39,14 @@ class CsvWriterImpl implements UnstructuredWriter {
     private char fieldDelimiter;
     private CsvWriter csvWriter;
 
-    public CsvWriterImpl(Writer writer, char fieldDelimiter) {
+    public CsvWriterImpl(Writer writer, char fieldDelimiter, boolean forceQualifier) {
         this.fieldDelimiter = fieldDelimiter;
         this.csvWriter = new CsvWriter(writer, this.fieldDelimiter);
         this.csvWriter.setTextQualifier('"');
         this.csvWriter.setUseTextQualifier(true);
         // warn: in linux is \n , in windows is \r\n
         this.csvWriter.setRecordDelimiter(IOUtils.LINE_SEPARATOR.charAt(0));
+        this.csvWriter.setForceQualifier(forceQualifier);
     }
 
     @Override

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/UnstructuredStorageWriterUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/UnstructuredStorageWriterUtil.java
@@ -263,8 +263,10 @@ public class UnstructuredStorageWriterUtil {
         char fieldDelimiter = config.getChar(Key.FIELD_DELIMITER,
                 Constant.DEFAULT_FIELD_DELIMITER);
 
+        boolean forceQualifier = config.getBool(Key.FORCE_QUALIFIER, Constant.DEFAULT_FORCE_QUALIFIER);
+
         UnstructuredWriter unstructuredWriter = TextCsvWriterManager
-                .produceUnstructuredWriter(fileFormat, fieldDelimiter, writer);
+                .produceUnstructuredWriter(fileFormat, fieldDelimiter, writer, forceQualifier);
 
         List<String> headers = config.getList(Key.HEADER, String.class);
         if (null != headers && !headers.isEmpty()) {


### PR DESCRIPTION
实际项目使用中，有用到BLOB字段数据同步，但碍于网络限制，只能走DB2FTP和FTP2DB的数据同步方式，故而衍生出为FTP插件增加BLOB类型支持的需求。