### PR TITLE
Update PostgresqlWriter.java

### DIFF
--- a/postgresqlwriter/src/main/java/com/alibaba/datax/plugin/writer/postgresqlwriter/PostgresqlWriter.java
+++ b/postgresqlwriter/src/main/java/com/alibaba/datax/plugin/writer/postgresqlwriter/PostgresqlWriter.java
@@ -69,7 +69,9 @@ public class PostgresqlWriter extends Writer {
 						return "?::int";
 					}else if("bit".equalsIgnoreCase(columnType)){
 						return "?::bit varying";
-					}
+					}else if("bigserial".equalsIgnoreCase(columnType)){
+                                                return "?::bigint";
+                                        }
 					return "?::" + columnType;
 				}
 			};


### PR DESCRIPTION
support  postgresql11 autoincrement column  type bigserial， solve problem of “org.postgresql.util.PSQLException: ERROR: type "bigserial" does not exist”