### PR TITLE
解决多JobContiner在同一个JVM下时统计报告合并时造成的报告日志为所有JobContiner中的所有任务的报告总合

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/container/util/JobAssignUtil.java
+++ b/core/src/main/java/com/alibaba/datax/core/container/util/JobAssignUtil.java
@@ -161,13 +161,19 @@ public final class JobAssignUtil {
                 }
             }
         }
-
+        Long jobId = taskGroupTemplate.getLong(CoreConstant.DATAX_CORE_CONTAINER_JOB_ID);
         Configuration tempTaskGroupConfig;
         for (int i = 0; i < taskGroupNumber; i++) {
             tempTaskGroupConfig = taskGroupTemplate.clone();
             tempTaskGroupConfig.set(CoreConstant.DATAX_JOB_CONTENT, taskGroupConfigList.get(i));
-            tempTaskGroupConfig.set(CoreConstant.DATAX_CORE_CONTAINER_TASKGROUP_ID, i);
-
+            //tempTaskGroupConfig.set(CoreConstant.DATAX_CORE_CONTAINER_TASKGROUP_ID, i);
+            /**
+             * 这里为会区分该统计信息属于哪个Jobcontiner 用字符串相连的原因是
+             * 1+3=4
+             * 2+2=4
+             * 用字符串相连可以规避这个问题
+             */
+            tempTaskGroupConfig.set(CoreConstant.DATAX_CORE_CONTAINER_TASKGROUP_ID,Integer.parseInt(jobId+ ""+ i));
             result.add(tempTaskGroupConfig);
         }
 

--- a/core/src/main/java/com/alibaba/datax/core/statistics/communication/Communication.java
+++ b/core/src/main/java/com/alibaba/datax/core/statistics/communication/Communication.java
@@ -40,6 +40,8 @@ public class Communication extends BaseObject implements Cloneable {
      */
     Map<String, List<String>> message;
 
+    private Long jobId;
+
     public Communication() {
         this.init();
     }
@@ -277,5 +279,12 @@ public class Communication extends BaseObject implements Cloneable {
     	return this.state == State.SUCCEEDED || this.state == State.FAILED	
     			|| this.state == State.KILLED;
     }
-    
+
+    public Long getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(Long jobId) {
+        this.jobId = jobId;
+    }
 }

--- a/core/src/main/java/com/alibaba/datax/core/statistics/communication/LocalTGCommunicationManager.java
+++ b/core/src/main/java/com/alibaba/datax/core/statistics/communication/LocalTGCommunicationManager.java
@@ -16,13 +16,20 @@ public final class LocalTGCommunicationManager {
         taskGroupCommunicationMap.put(taskGroupId, communication);
     }
 
-    public static Communication getJobCommunication() {
+    public static Communication getJobCommunication(Long jobId) {
         Communication communication = new Communication();
         communication.setState(State.SUCCEEDED);
 
         for (Communication taskGroupCommunication :
                 taskGroupCommunicationMap.values()) {
-            communication.mergeFrom(taskGroupCommunication);
+            if(taskGroupCommunication.getJobId()==null){
+                communication.mergeFrom(taskGroupCommunication);
+            }
+            if(taskGroupCommunication.getJobId()==null
+                    ||jobId.equals(taskGroupCommunication.getJobId())){ //如JOB在正式启动后过段时间才会设置JobId所以这里把getJobId为空的也合并进去
+                communication.mergeFrom(taskGroupCommunication);        //因为如果为空就说明里面啥都没有合并了也不会影响什么
+
+            }
         }
 
         return communication;

--- a/core/src/main/java/com/alibaba/datax/core/statistics/container/collector/ProcessInnerCollector.java
+++ b/core/src/main/java/com/alibaba/datax/core/statistics/container/collector/ProcessInnerCollector.java
@@ -11,7 +11,13 @@ public class ProcessInnerCollector extends AbstractCollector {
 
     @Override
     public Communication collectFromTaskGroup() {
-        return LocalTGCommunicationManager.getJobCommunication();
+        /**
+         * 在整合到JAVA中启动时会使多个Jobcontiner 使用同一个LocalTGCommunicationManager.taskGroupCommunicationMap
+         * taskGroupCommunicationMap中存放当前Job的分组情况一般KEY从0开始
+         * 因为是静态的共享的每个JobContiner的taskgroup都是从0开始这样就到导致新的jobcontiner的收集器会收集的老的jobcontiner中的统计信息
+         * 这里通过传指定的JobId来区分统计信息
+         */
+        return LocalTGCommunicationManager.getJobCommunication(this.getJobId());
     }
 
 }

--- a/core/src/main/java/com/alibaba/datax/core/statistics/container/communicator/taskgroup/StandaloneTGContainerCommunicator.java
+++ b/core/src/main/java/com/alibaba/datax/core/statistics/container/communicator/taskgroup/StandaloneTGContainerCommunicator.java
@@ -13,6 +13,7 @@ public class StandaloneTGContainerCommunicator extends AbstractTGContainerCommun
 
     @Override
     public void report(Communication communication) {
+        communication.setJobId(super.jobId);//给当前
         super.getReporter().reportTGCommunication(super.taskGroupId, communication);
     }
 

--- a/core/src/main/java/com/alibaba/datax/core/util/container/CoreConstant.java
+++ b/core/src/main/java/com/alibaba/datax/core/util/container/CoreConstant.java
@@ -148,6 +148,8 @@ public class CoreConstant {
 	public static final String CURRENT_SERVICE_USERNAME = "current.service.username";
     
 	public static final String CURRENT_SERVICE_PASSWORD = "current.service.password";
+	public static final String DATAX_JOB_CONTENT_WRITER_PARAMETER_JOBID = "job.content[0].writer.parameter.jobid";
+	public static final String DATAX_JOB_CONTENT_READER_PARAMETER_JOBID = "job.content[0].reader.parameter.jobid";
 
 	// ----------------------------- 环境变量 ---------------------------------
 

--- a/core/src/main/java/com/alibaba/datax/core/util/container/LoadUtil.java
+++ b/core/src/main/java/com/alibaba/datax/core/util/container/LoadUtil.java
@@ -12,8 +12,8 @@ import com.alibaba.datax.core.taskgroup.runner.WriterRunner;
 import com.alibaba.datax.core.util.FrameworkErrorCode;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by jingxing on 14-8-24.
@@ -46,6 +46,10 @@ public class LoadUtil {
      */
     private static Configuration pluginRegisterCenter;
 
+    private final static Map <Long ,Configuration> configurationSet = new ConcurrentHashMap<Long, Configuration>();
+    public static Map getConfigurationSet(){
+        return configurationSet;
+    }
     /**
      * jarLoader的缓冲
      */
@@ -56,9 +60,15 @@ public class LoadUtil {
      *
      * @param pluginConfigs
      */
-    public static void bind(Configuration pluginConfigs) {
+    public static synchronized void bind(Configuration pluginConfigs) {
         pluginRegisterCenter = pluginConfigs;
+        Long jobId = pluginConfigs.getLong(
+                CoreConstant.DATAX_CORE_CONTAINER_JOB_ID);
+        configurationSet.put(jobId,pluginConfigs);
+
     }
+
+
 
     private static String generatePluginKey(PluginType pluginType,
                                             String pluginName) {
@@ -67,10 +77,12 @@ public class LoadUtil {
     }
 
     private static Configuration getPluginConf(PluginType pluginType,
-                                               String pluginName) {
-        Configuration pluginConf = pluginRegisterCenter
+                                               String pluginName,Long jobId) {
+//        Configuration pluginConf = pluginRegisterCenter
+//                .getConfiguration(generatePluginKey(pluginType, pluginName));
+        Configuration pluginConf
+                = configurationSet.get(jobId)
                 .getConfiguration(generatePluginKey(pluginType, pluginName));
-
         if (null == pluginConf) {
             throw DataXException.asDataXException(
                     FrameworkErrorCode.PLUGIN_INSTALL_ERROR,
@@ -89,14 +101,14 @@ public class LoadUtil {
      * @return
      */
     public static AbstractJobPlugin loadJobPlugin(PluginType pluginType,
-                                                  String pluginName) {
+                                                  String pluginName,Long jobId) {
         Class<? extends AbstractPlugin> clazz = LoadUtil.loadPluginClass(
-                pluginType, pluginName, ContainerType.Job);
+                pluginType, pluginName, ContainerType.Job,jobId);
 
         try {
             AbstractJobPlugin jobPlugin = (AbstractJobPlugin) clazz
                     .newInstance();
-            jobPlugin.setPluginConf(getPluginConf(pluginType, pluginName));
+            jobPlugin.setPluginConf(getPluginConf(pluginType, pluginName,jobId));
             return jobPlugin;
         } catch (Exception e) {
             throw DataXException.asDataXException(
@@ -114,14 +126,14 @@ public class LoadUtil {
      * @return
      */
     public static AbstractTaskPlugin loadTaskPlugin(PluginType pluginType,
-                                                    String pluginName) {
+                                                    String pluginName,Long jobId) {
         Class<? extends AbstractPlugin> clazz = LoadUtil.loadPluginClass(
-                pluginType, pluginName, ContainerType.Task);
+                pluginType, pluginName, ContainerType.Task,jobId);
 
         try {
             AbstractTaskPlugin taskPlugin = (AbstractTaskPlugin) clazz
                     .newInstance();
-            taskPlugin.setPluginConf(getPluginConf(pluginType, pluginName));
+            taskPlugin.setPluginConf(getPluginConf(pluginType, pluginName,jobId));
             return taskPlugin;
         } catch (Exception e) {
             throw DataXException.asDataXException(FrameworkErrorCode.RUNTIME_ERROR,
@@ -137,9 +149,9 @@ public class LoadUtil {
      * @param pluginName
      * @return
      */
-    public static AbstractRunner loadPluginRunner(PluginType pluginType, String pluginName) {
+    public static AbstractRunner loadPluginRunner(PluginType pluginType, String pluginName,Long jobId) {
         AbstractTaskPlugin taskPlugin = LoadUtil.loadTaskPlugin(pluginType,
-                pluginName);
+                pluginName,jobId);
 
         switch (pluginType) {
             case READER:
@@ -165,9 +177,9 @@ public class LoadUtil {
     @SuppressWarnings("unchecked")
     private static synchronized Class<? extends AbstractPlugin> loadPluginClass(
             PluginType pluginType, String pluginName,
-            ContainerType pluginRunType) {
-        Configuration pluginConf = getPluginConf(pluginType, pluginName);
-        JarLoader jarLoader = LoadUtil.getJarLoader(pluginType, pluginName);
+            ContainerType pluginRunType,Long jobId) {
+        Configuration pluginConf = getPluginConf(pluginType, pluginName,jobId);
+        JarLoader jarLoader = LoadUtil.getJarLoader(pluginType, pluginName,jobId);
         try {
             return (Class<? extends AbstractPlugin>) jarLoader
                     .loadClass(pluginConf.getString("class") + "$"
@@ -178,8 +190,8 @@ public class LoadUtil {
     }
 
     public static synchronized JarLoader getJarLoader(PluginType pluginType,
-                                                      String pluginName) {
-        Configuration pluginConf = getPluginConf(pluginType, pluginName);
+                                                      String pluginName,Long jobId) {
+        Configuration pluginConf = getPluginConf(pluginType, pluginName,jobId);
 
         JarLoader jarLoader = jarLoaderCenter.get(generatePluginKey(pluginType,
                 pluginName));


### PR DESCRIPTION
当把Datax整合到JAVA项目中时并行执行多个JobContiner时由于JobContiner的分组切分没有区别JobId
也就是说保存统计报告的是一个类中的静态Map他的Key 从0到。。。一般为0这样当多个JobContiner启动时就会共用一个储存地址并且key值相同这样多个任务时不能统计到其中一个任务的执行情况
