### PR TITLE
datax任务不能正常退出

### DIFF
--- a/mysqlreader/pom.xml
+++ b/mysqlreader/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>5.1.35</version>
         </dependency>
 
 

--- a/mysqlwriter/pom.xml
+++ b/mysqlwriter/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>5.1.35</version>
         </dependency>
 	</dependencies>
 


### PR DESCRIPTION
当mysql出现异常时，datax任务会无法正常退出，根据线程栈来看，程序阻塞在com.alibaba.datax.plugin.rdbms.reader.CommonRdbmsReader第222行的finally中，这里是要关闭mysql连接。但是因为mysql-connector-java的5.1.34版本有bug，会导致程序阻塞，异常也没法抛出来，只能通过内存堆栈来看。
mysql-connector-java 这个问题在5.1.35版本已经测试OK，所以需要升级下版本
这里的问题参考如下地址：https://bugs.mysql.com/bug.php?id=75309

测试demo如下（5.1.34程序抛异常后无法退出，5.1.35测试通过）

import java.sql.*;
public class TestMain {
    public static void main(String[] args) throws Exception{
        Connection conn = DriverManager.getConnection("jdbc:mysql://192.168.10.11:3306/test", "root", "root");
        Statement st = conn.createStatement();
        st.setFetchSize(Integer.MIN_VALUE); // import
        ResultSet rs = null;
        try {
            rs = st.executeQuery("select 1+18446744073709551615");
//            rs = st.executeQuery("select 1");
            rs.next();
            System.out.println(rs.getInt(1));
        } catch (Throwable e) {
            e.printStackTrace();//  com.mysql.jdbc.MysqlDataTruncation: Data truncation: BIGINT UNSIGNED value is out of range in '(1 + 18446744073709551615)'
            rs.close(); // will block
            st.close();
            conn.close();
        }
    }
}