### PR TITLE
ReaderSplitUtil bug修复 && 功能改进

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Constant.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Constant.java
@@ -17,6 +17,8 @@ public final class Constant {
 
     public static String IS_TABLE_MODE = "isTableMode";
 
+    public static String EACH_TABLE_SPLIT_SIZE = "eachTableSplitSize";
+
     public final static String FETCH_SIZE = "fetchSize";
 
     public static String QUERY_SQL_TEMPLATE_WITHOUT_WHERE = "select %s from %s ";


### PR DESCRIPTION
1. Reader为RDBMS时，如果配置了多个jdbc url，且每个jdbc url均是单表模式，每张表切分的数量回成指数级上升而引起OOM。原因在于doSplit方法内单表模式时eachTableShouldSplittedNumber每个connection都*5。
2. 支持配置每张表的切分的数量