### PR TITLE
Add ssl authentication to mongodbreader and mongodbwriter 

### DIFF
--- a/mongodbreader/doc/mongodbreader.md
+++ b/mongodbreader/doc/mongodbreader.md
@@ -27,6 +27,12 @@ MongoDBReader通过Datax框架从MongoDB并行的读取数据，通过主控的J
 	                        "userPassword": "",
 	                        "dbName": "tag_per_data",
 	                        "collectionName": "tag_data12",
+                            "authDb": "authDb",
+                            "sslMode": "two-way",
+                            "trustStorePath": "/path/to/trustStore",
+                            "trustStorePwd": "",
+                            "keyStorePath": "/path/to/keyStore",
+                            "keyStorePwd": "",
 	                        "column": [
 	                            {
 	                                "name": "unique_id",
@@ -128,6 +134,12 @@ MongoDBReader通过Datax框架从MongoDB并行的读取数据，通过主控的J
 * userName：MongoDB的用户名。【选填】
 * userPassword： MongoDB的密码。【选填】
 * collectionName： MonogoDB的集合名。【必填】
+* authDb: MongoDB用户的鉴权数据库。【选填】
+* sslMode: MongoDB ssl/tls 加密访问选项，支持 two-way(双向验证) | client-authentication(服务端确认客服端身份，客服端直接信赖服务端) | no-authentication(双方均不验证证书，直接新任) 【选填】
+* trustStorePath: 信赖的证书库路径，client-authentication时不需要。【选填】
+* trustStorePwd: 信赖的证书库密码。【选填】
+* keyStorePath: client端证书和密钥库。【选填】
+* keyStorePwd: client端证书和密钥库密码。【选填】
 * column：MongoDB的文档列名。【必填】
 * name：Column的名字。【必填】
 * type：Column的类型。【选填】

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/KeyConstant.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/KeyConstant.java
@@ -94,4 +94,28 @@ public class KeyConstant {
     public static boolean isDocumentType(String type) {
         return type.startsWith(DOCUMENT_TYPE);
     }
+
+    /**
+     * sslMode: two-way | client-authentication | no-authentication
+     */
+    public static final String SSL_MODE = "sslMode";
+    /**
+     * trustStore path
+     */
+    public static final String TRUST_STORE_PATH = "trustStorePath";
+    /**
+     * trustStore password
+     */
+    public static final String TRUST_STORE_PWD = "trustStorePwd";
+    /**
+     * keyStore path
+     */
+    public static final String KEY_STORE_PATH = "keyStorePath";
+    /**
+     * keyStore password
+     */
+    public static final String KEY_STORE_PWD = "keyStorePwd";
+    public static boolean isValueTrue(String value){
+        return "true".equals(value);
+    }
 }

--- a/mongodbwriter/doc/mongodbwriter.md
+++ b/mongodbwriter/doc/mongodbwriter.md
@@ -55,6 +55,12 @@ MongoDBWriter通过Datax框架获取Reader生成的数据，然后将Datax支持
                         "userPassword": "",
                         "dbName": "tag_per_data",
                         "collectionName": "tag_data",
+                        "authDb": "authDb",
+                        "sslMode": "two-way",
+                        "trustStorePath": "/path/to/trustStore",
+                        "trustStorePwd": "",
+                        "keyStorePath": "/path/to/keyStore",
+                        "keyStorePwd": "",
                         "column": [
                             {
                                 "name": "unique_id",
@@ -133,6 +139,12 @@ MongoDBWriter通过Datax框架获取Reader生成的数据，然后将Datax支持
 * userName：MongoDB的用户名。【选填】
 * userPassword： MongoDB的密码。【选填】
 * collectionName： MonogoDB的集合名。【必填】
+* authDb: MongoDB用户的鉴权数据库。【选填】
+* sslMode: MongoDB ssl/tls 加密访问选项，支持 two-way(双向验证) | client-authentication(服务端确认客服端身份，客服端直接信赖服务端) | no-authentication(双方均不验证证书，直接新任) 【选填】
+* trustStorePath: 信赖的证书库路径，client-authentication时不需要。【选填】
+* trustStorePwd: 信赖的证书库密码。【选填】
+* keyStorePath: client端证书和密钥库。【选填】
+* keyStorePwd: client端证书和密钥库密码。【选填】
 * column：MongoDB的文档列名。【必填】
 * name：Column的名字。【必填】
 * type：Column的类型。【选填】

--- a/mongodbwriter/src/main/java/com/alibaba/datax/plugin/writer/mongodbwriter/KeyConstant.java
+++ b/mongodbwriter/src/main/java/com/alibaba/datax/plugin/writer/mongodbwriter/KeyConstant.java
@@ -25,6 +25,7 @@ public class KeyConstant {
      * mongodb 数据库名
      */
     public static final String MONGO_DB_NAME = "dbName";
+    public static final String MONGO_AUTHDB = "authDb";
     /**
      * mongodb 集合名
      */
@@ -61,6 +62,26 @@ public class KeyConstant {
      * 指定用来判断是否覆盖的 业务主键
      */
     public static final String UNIQUE_KEY = "replaceKey";
+    /**
+     * sslMode: two-way | client-authentication | no-authentication
+     */
+    public static final String SSL_MODE = "sslMode";
+    /**
+     * trustStore path
+     */
+    public static final String TRUST_STORE_PATH = "trustStorePath";
+    /**
+     * trustStore password
+     */
+    public static final String TRUST_STORE_PWD = "trustStorePwd";
+    /**
+     * keyStore path
+     */
+    public static final String KEY_STORE_PATH = "keyStorePath";
+    /**
+     * keyStore password
+     */
+    public static final String KEY_STORE_PWD = "keyStorePwd";
     /**
      * 判断是否为数组类型
      * @param type 数据类型

--- a/mongodbwriter/src/main/java/com/alibaba/datax/plugin/writer/mongodbwriter/util/MongoUtil.java
+++ b/mongodbwriter/src/main/java/com/alibaba/datax/plugin/writer/mongodbwriter/util/MongoUtil.java
@@ -5,10 +5,19 @@ import com.alibaba.datax.common.util.Configuration;
 import com.alibaba.datax.plugin.writer.mongodbwriter.KeyConstant;
 import com.alibaba.datax.plugin.writer.mongodbwriter.MongoDBWriterErrorCode;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 
+import javax.net.ssl.*;
+import java.io.FileInputStream;
 import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,6 +59,143 @@ public class MongoUtil {
             throw DataXException.asDataXException(MongoDBWriterErrorCode.UNEXCEPT_EXCEPTION,"未知异常");
         }
     }
+
+    /**
+     * two-way 双向SSL验证, DO NOT Use System.setProperty to set javax.net.ssl.trustStore, javax.net.ssl.keyStore
+     * @param conf
+     * @param userName
+     * @param password
+     * @param database
+     * @param trustStorePath 信赖的证书路径,.crt格式的证书需要转换为jdk支持的格式，如pkcs12
+     * @param trustStorePwd
+     * @param keyStorePath client端keystore,用于server端验证client身份
+     * @param keyStorePwd
+     * @return
+     */
+    public static MongoClient initCredentialSSLMongoClient(Configuration conf,String userName,String password,
+                           String database,String trustStorePath,String trustStorePwd,String keyStorePath,String keyStorePwd) {
+        List<Object> addressList = conf.getList(KeyConstant.MONGO_ADDRESS);
+        if(!isHostPortPattern(addressList)) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_VALUE,"不合法参数");
+        }
+        try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            // set up a KeyManager for validation of server side if required
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType()); // usually is jks
+            FileInputStream myKeyStore = new FileInputStream(keyStorePath);
+            keyStore.load(myKeyStore,keyStorePwd.toCharArray());
+            myKeyStore.close();
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory
+              .getDefaultAlgorithm()); // default SunX509
+            kmf.init(keyStore, keyStorePwd.toCharArray());
+            // set up a TrustManager that trusts everything
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            TrustManagerFactory tmf = TrustManagerFactory
+              .getInstance(TrustManagerFactory.getDefaultAlgorithm()); // default PKIX
+            FileInputStream myTrustStore = new FileInputStream(trustStorePath);
+            trustStore.load(myTrustStore,trustStorePwd.toCharArray());
+            myTrustStore.close();
+            tmf.init(trustStore);
+            sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+            // set opts
+            MongoCredential credential = MongoCredential.createCredential(userName, database, password.toCharArray());
+            MongoClientOptions opts = MongoClientOptions.builder().
+              sslEnabled(true).socketFactory(sslContext.getSocketFactory()).sslInvalidHostNameAllowed(true).build();
+            return new MongoClient(parseServerAddress(addressList), Arrays.asList(credential), opts);
+        } catch (UnknownHostException e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_ADDRESS,"不合法的地址");
+        } catch (NumberFormatException e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_VALUE,"不合法参数");
+        } catch (Exception e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.UNEXCEPT_EXCEPTION,"未知异常");
+        }
+    }
+
+    /**
+     * client-authentication 单向验证，始终相信服务端
+     * @param conf
+     * @param userName
+     * @param password
+     * @param database
+     * @param keyStorePath
+     * @param keyStorePwd
+     * @return
+     */
+    public static MongoClient initCredentialClientAuthenticationMongoClient(Configuration conf,String userName,
+                                                String password,String database,String keyStorePath,String keyStorePwd) {
+        List<Object> addressList = conf.getList(KeyConstant.MONGO_ADDRESS);
+        if(!isHostPortPattern(addressList)) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_VALUE,"不合法参数");
+        }
+        try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            // set up a KeyManager for validation of server side if required
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType()); // usually is jks
+            FileInputStream myKeyStore = new FileInputStream(keyStorePath);
+            keyStore.load(myKeyStore,keyStorePwd.toCharArray());
+            myKeyStore.close();
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory
+              .getDefaultAlgorithm()); // default SunX509
+            kmf.init(keyStore, keyStorePwd.toCharArray());
+            // set up a TrustManager that trusts everything
+            sslContext.init(kmf.getKeyManagers(), new TrustManager[] { new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
+                @Override
+                public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+            }}, new SecureRandom());
+            MongoCredential credential = MongoCredential.createCredential(userName, database, password.toCharArray());
+            MongoClientOptions opts = MongoClientOptions.builder().
+              sslEnabled(true).socketFactory(sslContext.getSocketFactory()).sslInvalidHostNameAllowed(true).build();
+            return new MongoClient(parseServerAddress(addressList), Arrays.asList(credential), opts);
+        } catch (UnknownHostException e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_ADDRESS,"不合法的地址");
+        } catch (NumberFormatException e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_VALUE,"不合法参数");
+        } catch (Exception e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.UNEXCEPT_EXCEPTION,"未知异常");
+        }
+    }
+
+    /**
+     * ssl通信，双向都不验证。不推荐。
+     * @param conf
+     * @param userName
+     * @param password
+     * @param database
+     * @return
+     */
+    public static MongoClient initCredentialNoAuthenticationMongoClient(Configuration conf,String userName,String password,
+                           String database) {
+        List<Object> addressList = conf.getList(KeyConstant.MONGO_ADDRESS);
+        if(!isHostPortPattern(addressList)) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_VALUE,"不合法参数");
+        }
+        try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new TrustManager[] { new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
+                @Override
+                public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+            }}, new SecureRandom());
+            MongoCredential credential = MongoCredential.createCredential(userName, database, password.toCharArray());
+            MongoClientOptions opts = MongoClientOptions.builder().
+              sslEnabled(true).socketFactory(sslContext.getSocketFactory()).sslInvalidHostNameAllowed(true).build();
+            return new MongoClient(parseServerAddress(addressList), Arrays.asList(credential), opts);
+        } catch (UnknownHostException e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_ADDRESS,"不合法的地址");
+        } catch (NumberFormatException e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.ILLEGAL_VALUE,"不合法参数");
+        } catch (Exception e) {
+            throw DataXException.asDataXException(MongoDBWriterErrorCode.UNEXCEPT_EXCEPTION,"未知异常");
+        }
+    }
+
     /**
      * 判断地址类型是否符合要求
      * @param addressList


### PR DESCRIPTION
Add ssl authentication to mongodbreader and mongodbwriter. Allowd ssl mode: two-way, client-authentication and no-authentication. 