### PR TITLE
mongodb游标默认10分钟限制

### DIFF
--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
@@ -120,7 +120,7 @@ public class MongoDBReader extends Reader {
                 Document queryFilter = Document.parse(query);
                 filter = new Document("$and", Arrays.asList(filter, queryFilter));
             }
-            dbCursor = col.find(filter).iterator();
+            dbCursor = col.find(filter).noCursorTimeout(true).iterator();
             while (dbCursor.hasNext()) {
                 Document item = dbCursor.next();
                 Record record = recordSender.createRecord();


### PR DESCRIPTION
设置游标不超时，数据量大的时候，抽取数据时间长会出现游标丢失异常
Query failed with error code -5 and error message 'Cursor 85789014536 not found