### PR TITLE
[Fix]解决最终metric中读写记录总数不一致问题

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
+++ b/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
@@ -141,14 +141,24 @@ public abstract class Channel {
 
     public Record pull() {
         Record record = this.doPull();
-        this.statPull(1L, record.getByteSize());
+        if (!(record instanceof TerminateRecord)) {
+            this.statPull(1L, record.getByteSize());
+        }
         return record;
     }
 
     public void pullAll(final Collection<Record> rs) {
         Validate.notNull(rs);
         this.doPullAll(rs);
-        this.statPull(rs.size(), this.getByteSize(rs));
+        if (rs.size() > 0) {
+            Record record = (Record) rs.toArray()[rs.size() - 1];
+            //TerminateRecord的bytesize=0，无需特殊处理
+            if (record instanceof TerminateRecord) {
+                this.statPull(rs.size() - 1, this.getByteSize(rs));
+            } else{
+                this.statPull(rs.size(), this.getByteSize(rs));
+            }
+        }
     }
 
     protected abstract void doPush(Record r);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/11826650/65825103-60060800-e2a5-11e9-9dc6-df3599075adf.png)
我们在增加自定义metric时,发现最终结果读写记录数不一致,而且写记录数总是比读记录数多,如上图.
最后发现原因是WRITE_RECEIVED_RECORDS metric把TerminateRecord标识记录统计在内.