### PR TITLE
更改 pom 版本号，解决外网用户无法编译通过。

### DIFF
--- a/odpsreader/pom.xml
+++ b/odpsreader/pom.xml
@@ -43,11 +43,11 @@
             <scope>system</scope>
             <systemPath>${basedir}/src/main/libs/bcprov-jdk15on-1.52.jar</systemPath>
         </dependency>
-		<dependency>
-			<groupId>com.aliyun.odps</groupId>
-			<artifactId>odps-sdk-core</artifactId>
-			<version>0.19.3-public</version>
-		</dependency>
+        <dependency>
+            <groupId>com.aliyun.odps</groupId>
+            <artifactId>odps-sdk-core</artifactId>
+            <version>0.20.7-public</version>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>

--- a/odpswriter/pom.xml
+++ b/odpswriter/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
 			<groupId>com.aliyun.odps</groupId>
 			<artifactId>odps-sdk-core</artifactId>
-			<version>0.19.3-public</version>
+			<version>0.20.7-public</version>
 		</dependency>
 
         <!-- httpclient begin -->

--- a/otsstreamreader/pom.xml
+++ b/otsstreamreader/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>tablestore-streamclient</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <module>tsdbwriter</module>
         <module>adbpgwriter</module>
         <module>gdbwriter</module>
-        
+
         <!-- common support module -->
         <module>plugin-rdbms-util</module>
         <module>plugin-unstructured-storage-util</module>
@@ -172,6 +172,34 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Nexus aliyun</name>
+            <url>https://maven.aliyun.com/repository/central</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>Nexus aliyun</name>
+            <url>https://maven.aliyun.com/repository/central</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <build>
         <plugins>


### PR DESCRIPTION
  datax pom 增加 aliyun 仓库镜像
  odpsreader 和 writer pom 修改 odps-sdk-core 为 0.20.7， 0.19.3 外网无法使用
  otsstreamreader pom 修改 client 为 1.0.0 正式版
-- 现有外网用户无法通过 mvn 命令编译