### PR TITLE
JOB_WRITER 变量值错误，对在配置文件校验处，放宽校验writer存在与否。

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/util/container/CoreConstant.java
+++ b/core/src/main/java/com/alibaba/datax/core/util/container/CoreConstant.java
@@ -105,7 +105,7 @@ public class CoreConstant {
 
     public static final String DATAX_JOB_POSTHANDLER_PLUGINNAME = "job.postHandler.pluginName";
     // ----------------------------- 局部使用的变量
-    public static final String JOB_WRITER = "reader";
+    public static final String JOB_WRITER = "writer";
 
 	public static final String JOB_READER = "reader";
 


### PR DESCRIPTION
JOB_WRITER 变量值错误，会影响校验准确性，建议修改。