### PR TITLE
增加hbase11xsqlwriter中连接Phoenix的相关配置项

### DIFF
--- a/hbase11xsqlwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xsqlwriter/HbaseSQLHelper.java
+++ b/hbase11xsqlwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xsqlwriter/HbaseSQLHelper.java
@@ -4,7 +4,6 @@ import com.alibaba.datax.common.exception.DataXException;
 import com.alibaba.datax.common.util.Configuration;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.TypeReference;
-import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.util.Pair;

--- a/hbase11xsqlwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xsqlwriter/HbaseSQLWriterConfig.java
+++ b/hbase11xsqlwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xsqlwriter/HbaseSQLWriterConfig.java
@@ -9,7 +9,6 @@ import org.apache.hadoop.hbase.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;

--- a/hbase11xsqlwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xsqlwriter/Key.java
+++ b/hbase11xsqlwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xsqlwriter/Key.java
@@ -8,12 +8,15 @@ public final class Key {
      * 【必选】hbase集群配置，连接一个hbase集群需要的最小配置只有两个：zk和znode
      */
     public final static String HBASE_CONFIG = "hbaseConfig";
+    public final static String PHOENIX_CONFIG = "phoenixConfig";
     public final static String HBASE_ZK_QUORUM = HConstants.ZOOKEEPER_QUORUM;
     public final static String HBASE_ZNODE_PARENT = HConstants.ZOOKEEPER_ZNODE_PARENT;
     public final static String HBASE_THIN_CONNECT_URL = "hbase.thin.connect.url";
     public final static String HBASE_THIN_CONNECT_NAMESPACE = "hbase.thin.connect.namespace";
     public final static String HBASE_THIN_CONNECT_USERNAME = "hbase.thin.connect.username";
     public final static String HBASE_THIN_CONNECT_PASSWORD = "hbase.thin.connect.password";
+    public final static String PHOENIX_SCHEMA_IS_NAMESPACE_MAPPING_ENABLED = "phoenix.schema.isNamespaceMappingEnabled";
+    public final static String PHOENIX_SCHEMA_MAP_SYSTEM_TABLES_TO_NAMESPACE = "phoenix.schema.mapSystemTablesToNamespace";
 
     /**
      * 【必选】writer要写入的表的表名


### PR DESCRIPTION
### 当前问题

当使用HBase中的自定义namespace时，客户端想要连接Phoenix需要指定phoenix.schema.isNamespaceMappingEnabled配置参数为true，否则会抛出如下异常：

```txt
java.sql.SQLException: ERROR 726 (43M10):  Inconsistent namespace mapping properites.. Cannot initiate connection as SYSTEM:CATALOG is found but client does not have phoenix.schema.isNamespaceMappingEnabled enabled
```

### 解决问题
此PR增加了phoenixConfig配置项解决此问题，JSON文件格式如下：

```json
"writer": {
    "name": "hbase11xsqlwriter",
    "parameter": {
        "batchSize": "256",
        "column": [
            "ID",
            "NAME",
            "HOME"
        ],
        "phoenixConfig": {
            "phoenix.schema.isNamespaceMappingEnabled": "true",
            "phoenix.schema.mapSystemTablesToNamespace": "true"
        },
        "hbaseConfig": {
            "hbase.zookeeper.quorum": "127.0.0.1",
            "hbase.zookeeper.property.clientPort": "2181",
            "zookeeper.znode.parent": "/hbase"
        },
        "nullMode": "skip",
        "table": "USER"
    }
}
```

### 注意事项
增加了以下两项Phoenix连接配置，如果没有此需求无需配置phoenixConfig，默认传递false。

* phoenix.schema.isNamespaceMappingEnabled
* phoenix.schema.mapSystemTablesToNamespace