### PR TITLE
 硬改版本，不建议合并，有短期需求的自取。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ![Datax-logo](https://github.com/alibaba/DataX/blob/master/images/DataX-logo.jpg)
 
+# hardcode
+1. 为了支持Postgres的JSONB字段: querySql: column::json#>>'{}'
+2. 为了支持Postgres的UPDATE: "writeMode": "update",
 
+为了实现业务需求，没有完整的按照DataX的结构进行开发。
+具体改动可以看提交详情。
 
 # DataX
 

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
@@ -410,6 +410,10 @@ public class CommonRdbmsWriter {
 
         protected PreparedStatement fillPreparedStatementColumnType(PreparedStatement preparedStatement, int columnIndex, int columnSqltype, Column column) throws SQLException {
             java.util.Date utilDate;
+            //针对metadata做强制columnSqltype转换
+            if(this.resultSetMetaData.getRight().get(columnIndex).startsWith("jsonb")) {
+                columnSqltype = Types.LONGNVARCHAR;
+            }
             switch (columnSqltype) {
                 case Types.CHAR:
                 case Types.NCHAR:

--- a/postgresqlwriter/src/main/java/com/alibaba/datax/plugin/writer/postgresqlwriter/PostgresqlWriter.java
+++ b/postgresqlwriter/src/main/java/com/alibaba/datax/plugin/writer/postgresqlwriter/PostgresqlWriter.java
@@ -23,11 +23,11 @@ public class PostgresqlWriter extends Writer {
 			this.originalConfig = super.getPluginJobConf();
 
 			// warn：not like mysql, PostgreSQL only support insert mode, don't use
-			String writeMode = this.originalConfig.getString(Key.WRITE_MODE);
-			if (null != writeMode) {
-				throw DataXException.asDataXException(DBUtilErrorCode.CONF_ERROR,
-					String.format("写入模式(writeMode)配置有误. 因为PostgreSQL不支持配置参数项 writeMode: %s, PostgreSQL仅使用insert sql 插入数据. 请检查您的配置并作出修改.", writeMode));
-			}
+			// String writeMode = this.originalConfig.getString(Key.WRITE_MODE);
+			// if (null != writeMode) {
+			// 	throw DataXException.asDataXException(DBUtilErrorCode.CONF_ERROR,
+			// 		String.format("写入模式(writeMode)配置有误. 因为PostgreSQL不支持配置参数项 writeMode: %s, PostgreSQL仅使用insert sql 插入数据. 请检查您的配置并作出修改.", writeMode));
+			// }
 
 			this.commonRdbmsWriterMaster = new CommonRdbmsWriter.Job(DATABASE_TYPE);
 			this.commonRdbmsWriterMaster.init(this.originalConfig);


### PR DESCRIPTION
1. 为了支持Postgres的JSONB字段: querySql: column::json#>>'{}'
2. 为了支持Postgres的UPDATE: "writeMode": "update",

为了实现业务需求，没有完整的按照DataX的结构进行开发。
具体改动可以看提交详情。