### PR TITLE
txtfilewriter列分隔符支持ASCII编码以实体编码方式配置

### DIFF
--- a/txtfilewriter/doc/txtfilewriter.md
+++ b/txtfilewriter/doc/txtfilewriter.md
@@ -123,7 +123,7 @@ TxtFileWriter实现了从DataX协议转为本地TXT文件功能，本地文件�
 
 * **fieldDelimiter**
 
-	* 描述：读取的字段分隔符 <br />
+	* 描述：写入的字段分隔符；支持ASCII码以实体编码的方式配置为分隔符，例如"&#30;"，表示ASCII码为30的字符(https://baike.baidu.com/item/ASCII/309296?fr=aladdin) <br />
 
 	* 必选：否 <br />
 

--- a/txtfilewriter/src/main/java/com/alibaba/datax/plugin/writer/txtfilewriter/TxtFileWriter.java
+++ b/txtfilewriter/src/main/java/com/alibaba/datax/plugin/writer/txtfilewriter/TxtFileWriter.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by haiwei.luo on 14-9-17.
@@ -63,6 +65,17 @@ public class TxtFileWriter extends Writer {
             String path = this.writerSliceConfig.getNecessaryValue(Key.PATH,
                     TxtFileWriterErrorCode.REQUIRED_VALUE);
 
+            String fieldDelimiter = this.writerSliceConfig.getString(com.alibaba.datax.plugin.unstructuredstorage.writer.Key.FIELD_DELIMITER);
+            if(null != fieldDelimiter) {
+            	String pattern = "&#(\\d{1,3});";
+        		Pattern r = Pattern.compile(pattern);
+        		Matcher m = r.matcher(fieldDelimiter);
+        		if (m.find()) {
+        			char code = (char)Integer.parseInt(m.group(1));
+        			this.writerSliceConfig.set(com.alibaba.datax.plugin.unstructuredstorage.writer.Key.FIELD_DELIMITER, code);
+        			LOG.info(String.format("fieldDelimiter配置为ASCII实体编码[%s], 转换为字符[%c]", fieldDelimiter, code));
+        		}
+            }
             try {
                 // warn: 这里用户需要配一个目录
                 File dir = new File(path);


### PR DESCRIPTION
写入的字段分隔符，支持ASCII码以实体编码的方式配置为分隔符。
例如：
    "&amp;#30;"，表示ASCII码为30的字符(https://baike.baidu.com/item/ASCII/309296?fr=aladdin)