### PR TITLE
DATAX插件HdfsReader支持parquet格式，功能提交

### DIFF
--- a/hdfsreader/pom.xml
+++ b/hdfsreader/pom.xml
@@ -6,13 +6,12 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>hdfsreader</artifactId>
     <groupId>com.alibaba.datax</groupId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
-        <hive.version>1.1.1</hive.version>
+        <hive.version>2.1.1</hive.version>
         <hadoop.version>2.7.1</hadoop.version>
     </properties>
     <dependencies>
@@ -95,6 +94,13 @@
             <version>${datax-project-version}</version>
         </dependency>
 
+
+        <!-- https://mvnrepository.com/artifact/com.twitter/parquet-tools -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-tools</artifactId>
+            <version>1.8.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/Constant.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/Constant.java
@@ -10,4 +10,5 @@ public class Constant {
     public static final String CSV = "CSV";
     public static final String SEQ = "SEQ";
     public static final String RC = "RC";
+    public static final String PAR = "PAR";
 }

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
@@ -15,12 +15,15 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hive.ql.io.RCFile;
 import org.apache.hadoop.hive.ql.io.RCFileRecordReader;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.io.orc.Reader;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.hive.serde2.columnar.BytesRefArrayWritable;
 import org.apache.hadoop.hive.serde2.columnar.BytesRefWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
@@ -29,8 +32,16 @@ import org.apache.hadoop.io.*;
 import org.apache.hadoop.mapred.*;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ReflectionUtils;
+
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.tools.read.SimpleReadSupport;
+import org.apache.parquet.tools.read.SimpleRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -363,6 +374,79 @@ public class DFSUtil {
         }
     }
 
+    public void parquetFileStartRead(String sourceOrcFilePath, Configuration readerSliceConfig,
+                                     RecordSender recordSender, TaskPluginCollector taskPluginCollector) {
+        LOG.info(String.format("Start Read parquetfile [%s].", sourceOrcFilePath));
+        List<ColumnEntry> column = UnstructuredStorageReaderUtil
+                .getListColumnEntry(readerSliceConfig, com.alibaba.datax.plugin.unstructuredstorage.reader.Key.COLUMN);
+        String nullFormat = readerSliceConfig.getString(com.alibaba.datax.plugin.unstructuredstorage.reader.Key.NULL_FORMAT);
+        StringBuilder allColumns = new StringBuilder();
+        StringBuilder allColumnTypes = new StringBuilder();
+        boolean isReadAllColumns = false;
+        int columnIndexMax = -1;
+        // 判断是否读取所有列
+        if (null == column || column.size() == 0) {
+            int allColumnsCount = getAllColumnsCount_parquet(sourceOrcFilePath);
+            columnIndexMax = allColumnsCount - 1;
+            isReadAllColumns = true;
+        } else {
+            columnIndexMax = getMaxIndex(column);
+        }
+        for (int i = 0; i <= columnIndexMax; i++) {
+            allColumns.append("col");
+            allColumnTypes.append("string");
+            if (i != columnIndexMax) {
+                allColumns.append(",");
+                allColumnTypes.append(":");
+            }
+        }
+        if (columnIndexMax >= 0) {
+            JobConf conf = new JobConf(hadoopConf);
+            Path parquetFilePath = new Path(sourceOrcFilePath);
+            Properties p = new Properties();
+            p.setProperty("columns", allColumns.toString());
+            p.setProperty("columns.types", allColumnTypes.toString());
+            try {
+                ParquetHiveSerDe serde = new ParquetHiveSerDe();
+                serde.initialize(conf, p);
+                StructObjectInspector inspector = (StructObjectInspector) serde.getObjectInspector();
+                InputFormat<?, ?> in = new MapredParquetInputFormat();
+                FileInputFormat.setInputPaths(conf, parquetFilePath.toString());
+
+                //If the network disconnected, will retry 45 times, each time the retry interval for 20 seconds
+                //Each file as a split
+                //TODO multy threads
+                InputSplit[] splits = in.getSplits(conf, 1);
+
+                RecordReader reader = in.getRecordReader(splits[0], conf, Reporter.NULL);
+                Object key = reader.createKey();
+                Object value = reader.createValue();
+                // 获取列信息
+                List<? extends StructField> fields = inspector.getAllStructFieldRefs();
+
+                List<Object> recordFields;
+                while (reader.next(key, value)) {
+                    recordFields = new ArrayList<Object>();
+
+                    for (int i = 0; i <= columnIndexMax; i++) {
+                        Object field = inspector.getStructFieldData(value, fields.get(i));
+                        recordFields.add(field);
+                    }
+                    transportOneRecord(column, recordFields, recordSender, taskPluginCollector, isReadAllColumns, nullFormat);
+                }
+                reader.close();
+            } catch (Exception e) {
+                String message = String.format("从parquetfile文件路径[%s]中读取数据发生异常，请联系系统管理员。"
+                        , sourceOrcFilePath);
+                LOG.error(message);
+                throw DataXException.asDataXException(HdfsReaderErrorCode.READ_FILE_ERROR, message);
+            }
+        } else {
+            String message = String.format("请确认您所读取的列配置正确！columnIndexMax 小于0,column:%s", JSON.toJSONString(column));
+            throw DataXException.asDataXException(HdfsReaderErrorCode.BAD_CONFIG_VALUE, message);
+        }
+    }
+
     private Record transportOneRecord(List<ColumnEntry> columnConfigs, List<Object> recordFields
             , RecordSender recordSender, TaskPluginCollector taskPluginCollector, boolean isReadAllColumns, String nullFormat) {
         Record record = recordSender.createRecord();
@@ -387,8 +471,9 @@ public class DFSUtil {
                     String columnValue = null;
 
                     if (null != columnIndex) {
-                        if (null != recordFields.get(columnIndex))
+                        if (null != recordFields.get(columnIndex)){
                             columnValue = recordFields.get(columnIndex).toString();
+                        }
                     } else {
                         columnValue = columnConst;
                     }
@@ -496,6 +581,19 @@ public class DFSUtil {
         }
     }
 
+    private int getAllColumnsCount_parquet(String filePath) {
+        int columnsCount;
+        Path path = new Path(filePath);
+        try {
+            ParquetMetadata readerFooter = ParquetFileReader.readFooter(hadoopConf, path, ParquetMetadataConverter.NO_FILTER);
+            columnsCount = readerFooter.getFileMetaData().getSchema().getColumns().size();
+            return columnsCount;
+        } catch (IOException e) {
+            String message = "读取orcfile column列数失败，请联系系统管理员";
+            throw DataXException.asDataXException(HdfsReaderErrorCode.READ_FILE_ERROR, message);
+        }
+    }
+
     private int getMaxIndex(List<ColumnEntry> columnConfigs) {
         int maxIndex = -1;
         for (ColumnEntry columnConfig : columnConfigs) {
@@ -539,8 +637,12 @@ public class DFSUtil {
                 if (isSEQ) {
                     return false;
                 }
+                boolean isPar = isPARFile(file, in);
+                if (isPar) {
+                    return false;
+                }
                 // 如果不是ORC,RC和SEQ,则默认为是TEXT或CSV类型
-                return !isORC && !isRC && !isSEQ;
+                return !isORC && !isRC && !isSEQ && !isPar;
 
             } else if (StringUtils.equalsIgnoreCase(specifiedFileType, Constant.ORC)) {
 
@@ -551,6 +653,8 @@ public class DFSUtil {
             } else if (StringUtils.equalsIgnoreCase(specifiedFileType, Constant.SEQ)) {
 
                 return isSequenceFile(filepath, in);
+            } else if (StringUtils.equalsIgnoreCase(specifiedFileType, Constant.PAR)) {
+                return isPARFile(file, in);
             }
 
         } catch (Exception e) {
@@ -601,6 +705,24 @@ public class DFSUtil {
             }
         } catch (IOException e) {
             LOG.info(String.format("检查文件类型: [%s] 不是ORC File.", file.toString()));
+        }
+        return false;
+    }
+    //判断是否为parquet
+    private boolean isPARFile(Path file, FSDataInputStream in) {
+
+
+        try {
+            hadoopConf.set("fs.hdfs.impl", DistributedFileSystem.class.getName());
+            System.out.println(JSON.toJSONString(hadoopConf));
+            ParquetReader<SimpleRecord> reader = ParquetReader.builder(new SimpleReadSupport(), file).withConf(hadoopConf).build();
+            if (reader.read() != null) {
+                return true;
+            }
+
+
+        } catch (IOException e) {
+            LOG.info(String.format("检查文件类型: [%s] 不是PAR File.", file.toString()));
         }
         return false;
     }

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
@@ -589,7 +589,7 @@ public class DFSUtil {
             columnsCount = readerFooter.getFileMetaData().getSchema().getColumns().size();
             return columnsCount;
         } catch (IOException e) {
-            String message = "读取orcfile column列数失败，请联系系统管理员";
+            String message = "读取parquet column列数失败，请联系系统管理员";
             throw DataXException.asDataXException(HdfsReaderErrorCode.READ_FILE_ERROR, message);
         }
     }

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
@@ -386,7 +386,7 @@ public class DFSUtil {
         int columnIndexMax = -1;
         // 判断是否读取所有列
         if (null == column || column.size() == 0) {
-            int allColumnsCount = getAllColumnsCount_parquet(sourceOrcFilePath);
+            int allColumnsCount = getAllColumnsCountByparquet(sourceOrcFilePath);
             columnIndexMax = allColumnsCount - 1;
             isReadAllColumns = true;
         } else {
@@ -581,7 +581,7 @@ public class DFSUtil {
         }
     }
 
-    private int getAllColumnsCount_parquet(String filePath) {
+    private int getAllColumnsCountByparquet(String filePath) {
         int columnsCount;
         Path path = new Path(filePath);
         try {

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/HdfsFileType.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/HdfsFileType.java
@@ -5,5 +5,5 @@ package com.alibaba.datax.plugin.reader.hdfsreader;
  *
  */
 public enum HdfsFileType {
-    ORC, SEQ, RC, CSV, TEXT,
+    ORC, SEQ, RC, CSV, TEXT,PAR,
 }

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/HdfsReader.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/HdfsReader.java
@@ -81,9 +81,10 @@ public class HdfsReader extends Reader {
                     !specifiedFileType.equalsIgnoreCase(Constant.TEXT) &&
                     !specifiedFileType.equalsIgnoreCase(Constant.CSV) &&
                     !specifiedFileType.equalsIgnoreCase(Constant.SEQ) &&
-                    !specifiedFileType.equalsIgnoreCase(Constant.RC)){
-                String message = "HdfsReader插件目前支持ORC, TEXT, CSV, SEQUENCE, RC五种格式的文件," +
-                        "请将fileType选项的值配置为ORC, TEXT, CSV, SEQUENCE 或者 RC";
+                    !specifiedFileType.equalsIgnoreCase(Constant.RC)&&
+                    !specifiedFileType.equalsIgnoreCase(Constant.PAR)){
+                String message = "HdfsReader插件目前支持ORC, TEXT, CSV, SEQUENCE, RC,PAR 六种格式的文件," +
+                        "请将fileType选项的值配置为ORC, TEXT, CSV, SEQUENCE,PAR 或者 RC";
                 throw DataXException.asDataXException(HdfsReaderErrorCode.FILE_TYPE_ERROR, message);
             }
 
@@ -270,9 +271,11 @@ public class HdfsReader extends Reader {
                 }else if(specifiedFileType.equalsIgnoreCase(Constant.SEQ)){
 
                     dfsUtil.sequenceFileStartRead(sourceFile, this.taskConfig, recordSender, this.getTaskPluginCollector());
-                }else if(specifiedFileType.equalsIgnoreCase(Constant.RC)){
+                }else if(specifiedFileType.equalsIgnoreCase(Constant.RC)) {
 
                     dfsUtil.rcFileStartRead(sourceFile, this.taskConfig, recordSender, this.getTaskPluginCollector());
+                }else if (specifiedFileType.equalsIgnoreCase(Constant.PAR)) {
+                        dfsUtil.parquetFileStartRead(sourceFile, this.taskConfig, recordSender, this.getTaskPluginCollector());
                 }else {
 
                     String message = "HdfsReader插件目前支持ORC, TEXT, CSV, SEQUENCE, RC五种格式的文件," +


### PR DESCRIPTION
fix #162  DATAX插件HdfsWriter为什么不支持Parquet格式？ 

功能主要实现hdfsreader对parquet文件格式的支持 @binaryWorld  @TrafalgarLuo 

parquet两种压缩方式：snappy，gz 格式，已经测试。数据转换逻辑复用orcfile逻辑

测试截图如下：
![image](https://user-images.githubusercontent.com/59079269/72717865-d3fb5180-3baf-11ea-8a19-20c0bd00199e.png)

thanks