### PR TITLE
opentsdb读取任务设置多指标只能读取到第一个指标bug

### DIFF
--- a/opentsdbreader/src/main/java/com/alibaba/datax/plugin/reader/opentsdbreader/OpenTSDBReader.java
+++ b/opentsdbreader/src/main/java/com/alibaba/datax/plugin/reader/opentsdbreader/OpenTSDBReader.java
@@ -189,7 +189,12 @@ public class OpenTSDBReader extends Reader {
         public void startRead(RecordSender recordSender) {
             try {
                 for (String column : columns) {
-                    conn.sendDPs(column, this.startTime, this.endTime, recordSender);
+                    //If some metric does not exist, it is not a fatal error. Just log it and do not affect other jobs.
+                    try {
+                        conn.sendDPs(column, this.startTime, this.endTime, recordSender);
+                    }catch(net.opentsdb.uid.NoSuchUniqueName e){
+                        LOG.warn("在时间段{}-{}无{}指标", this.startTime,this.endTime,column);
+                    }
                 }
             } catch (Exception e) {
                 throw DataXException.asDataXException(

--- a/opentsdbreader/src/main/java/com/alibaba/datax/plugin/reader/opentsdbreader/OpenTSDBReader.java
+++ b/opentsdbreader/src/main/java/com/alibaba/datax/plugin/reader/opentsdbreader/OpenTSDBReader.java
@@ -124,12 +124,13 @@ public class OpenTSDBReader extends Reader {
             if (TimeUtils.isSecond(endTime)) {
                 endTime *= 1000;
             }
-            DateTime startDateTime = new DateTime(TimeUtils.getTimeInHour(startTime));
-            DateTime endDateTime = new DateTime(TimeUtils.getTimeInHour(endTime));
-
+            DateTime startDateTime=null;
+            DateTime endDateTime=new DateTime(TimeUtils.getTimeInHour(endTime));
             // split by metric
             for (String column : columns) {
                 // split by time in hour
+                //When the metric is multiple, the startDateTime needs to be reset
+                startDateTime = new DateTime(TimeUtils.getTimeInHour(startTime));
                 while (startDateTime.isBefore(endDateTime)) {
                     Configuration clone = this.originalConfig.clone();
                     clone.set(Key.COLUMN, Collections.singletonList(column));


### PR DESCRIPTION
opentsdb读取设置为多指标时，startDateTime会被加1小时后重新赋值，当第一个指标拆分完成后，
后面的指标不再满足startDateTime.isBefore(endDateTime)的条件，需要对startDateTime重新赋值。