### PR TITLE
修复ClickhouseWriter缺少包的问题 #661 #676

### DIFF
--- a/clickhousewriter/pom.xml
+++ b/clickhousewriter/pom.xml
@@ -30,12 +30,6 @@
             <version>${datax-project-version}</version>
         </dependency>
         <dependency>
-            <groupId>com.alibaba.datax</groupId>
-            <artifactId>simulator</artifactId>
-            <version>${datax-project-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/clickhousewriter/src/main/java/com/alibaba/datax/plugin/writer/clickhousewriter/ClickhouseWriter.java
+++ b/clickhousewriter/src/main/java/com/alibaba/datax/plugin/writer/clickhousewriter/ClickhouseWriter.java
@@ -12,7 +12,6 @@ import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
 import com.alibaba.datax.plugin.rdbms.writer.CommonRdbmsWriter;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
-import ru.yandex.clickhouse.ClickHouseTuple;
 
 import java.sql.Array;
 import java.sql.Connection;


### PR DESCRIPTION
# 问题

1. ClickhouseWriter 模块，因不存在 com.alibaba.datax-simulator 模块，编译失败
2. ClickhouseWriter.java 中多了未使用的导入类`ru.yandex.clickhouse.ClickHouseTuple`

# 解决方案

删除未使用的包和导入类