### PR TITLE
fix bug 因设置时间格式，造成ESwrite写入失败

### DIFF
--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESWriter.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESWriter.java
@@ -300,10 +300,10 @@ public class ESWriter extends Writer {
             if (column.getType() != Column.Type.DATE && esColumn.getFormat() != null) {
                 DateTimeFormatter formatter = DateTimeFormat.forPattern(esColumn.getFormat());
                 date = formatter.withZone(dtz).parseDateTime(column.asString());
-                return date.toString();
+                return date.toString(esColumn.getFormat());
             } else if (column.getType() == Column.Type.DATE) {
                 date = new DateTime(column.asLong(), dtz);
-                return date.toString();
+                return date.toString(esColumn.getFormat());
             } else {
                 return column.asString();
             }


### PR DESCRIPTION
当ES date 类型设置format 格式时，会出现数据不兼容的情况 

DateTime.toString() 默认的格式化方式为: ISODateTimeFormat，被格式化后时间字符串无法与ES执行format 格式兼容，导致数据写入失败。