### PR TITLE
bug fix gdb module 缺少依赖导致打包失败#727

### DIFF
--- a/clickhousewriter/src/main/java/com/alibaba/datax/plugin/writer/clickhousewriter/ClickhouseWriter.java
+++ b/clickhousewriter/src/main/java/com/alibaba/datax/plugin/writer/clickhousewriter/ClickhouseWriter.java
@@ -12,7 +12,6 @@ import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
 import com.alibaba.datax.plugin.rdbms.writer.CommonRdbmsWriter;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
-import ru.yandex.clickhouse.ClickHouseTuple;
 
 import java.sql.Array;
 import java.sql.Connection;

--- a/gdbreader/pom.xml
+++ b/gdbreader/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>lombok</artifactId>
             <version>1.18.8</version>
         </dependency>
+	<dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>1.12.1</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/gdbwriter/pom.xml
+++ b/gdbwriter/pom.xml
@@ -66,6 +66,11 @@
           	<artifactId>caffeine</artifactId>
           	<version>2.4.0</version>
         </dependency>
+	<dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>1.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
master使用mvn打包不成功 ：

gdbwriter和gdbreader模块中缺少依赖com.squareup.javapoet
clickhousewriter ： com.alibaba.datax.plugin.writer.clickhousewriter.ClickhouseWriter中引入了不存在的类 import ru.yandex.clickhouse.ClickHouseTuple;
