### PR TITLE
Update txtfilewriter.md

### DIFF
--- a/txtfilewriter/doc/txtfilewriter.md
+++ b/txtfilewriter/doc/txtfilewriter.md
@@ -187,7 +187,6 @@ TxtFileWriter实现了从DataX协议转为本地TXT文件功能，本地文件�
 
 | DataX 内部类型| 本地文件 数据类型    |
 | -------- | -----  |
-|
 | Long     |Long |
 | Double   |Double|
 | String   |String|


### PR DESCRIPTION
3.3 类型转换处 表格格式 markdown 不识别，已转成 可识别的样子