### PR TITLE
datax修改部分：

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -40,6 +40,9 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/net.hydromatic/eigenbase-properties -->
+
+
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESWriter.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESWriter.java
@@ -441,10 +441,10 @@ public class ESWriter extends Writer {
                                         } catch (Exception e) {
                                             String[] json = text.substring(1,text.length()-1).split("\",\"");
                                             parse = new HashMap();
-                                            for (int i0=0;i0<json.length;i0++) {
-                                                String item=json[i0];
-                                                if(i0==0) item=item.substring(1);
-                                                if(i0==json.length-1) item=item.substring(0,item.length()-1);
+                                            for (int ii=0;ii<json.length;ii++) {
+                                                String item=json[ii];
+                                                if(ii==0) item=item.substring(1);
+                                                if(ii==json.length-1) item=item.substring(0,item.length()-1);
                                                 String[] kv = item.split("\":\"");
                                                 String key = kv[0].replace("\"","");
                                                 String value=null;

--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/Key.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/Key.java
@@ -122,7 +122,7 @@ public final class Key {
     }
 
     public static String getSplitter(Configuration conf) {
-        return conf.getString("splitter", "-,-");
+        return conf.getString("splitter", "|");
     }
 
     public static boolean getDynamic(Configuration conf) {

--- a/hdfsreader/pom.xml
+++ b/hdfsreader/pom.xml
@@ -94,6 +94,21 @@
             <artifactId>plugin-unstructured-storage-util</artifactId>
             <version>${datax-project-version}</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/net.hydromatic/eigenbase-properties -->
+        <dependency>
+            <groupId>eigenbase</groupId>
+            <artifactId>eigenbase-properties</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.pentaho/pentaho-aggdesigner-algorithm -->
+        <dependency>
+            <groupId>org.pentaho</groupId>
+            <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+            <version>5.1.5-jhyde</version>
+            <scope>test</scope>
+        </dependency>
+
+
 
     </dependencies>
 
@@ -126,6 +141,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>${project-sourceEncoding}</encoding>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
@@ -167,7 +167,10 @@ public class DFSUtil {
                 LOG.info(String.format("[%s] 是目录, 递归获取该目录下的文件", f.getPath().toString()));
                 getHDFSAllFilesNORegex(f.getPath().toString(), hdfs);
             } else if (f.isFile()) {
-
+                if(f.getLen()==0){
+                    String message=String.format("文件[%s]长度为0,跳过不做处理",f.getPath().toString());
+                    LOG.warn(message);
+                }else
                 addSourceFileByType(f.getPath().toString());
             } else {
                 String message = String.format("该路径[%s]文件类型既不是目录也不是文件，插件自动忽略。",

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
@@ -283,12 +283,13 @@ public class UnstructuredStorageReaderUtil {
 
 			setCsvReaderConfig(csvReader);
 
-			String[] parseRows;
-			while ((parseRows = UnstructuredStorageReaderUtil
-					.splitBufferedReader(csvReader)) != null) {
-				UnstructuredStorageReaderUtil.transportOneRecord(recordSender,
-						column, parseRows, nullFormat, taskPluginCollector);
+
+			String line = null;
+			while ((line = reader.readLine()) != null) {
+				String[] parseRows = line.split(delimiterInStr, -1);
+				UnstructuredStorageReaderUtil.transportOneRecord(recordSender,column, parseRows, nullFormat, taskPluginCollector);
 			}
+
 		} catch (UnsupportedEncodingException uee) {
 			throw DataXException
 					.asDataXException(

--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,12 @@
         <module>hbase11xsqlwriter</module>
         <module>hbase11xsqlreader</module>
         <module>elasticsearchwriter</module>
-        <module>tsdbwriter</module>
+<!--&lt;!&ndash;        <module>tsdbwriter</module>&ndash;&gt;-->
         <module>adbpgwriter</module>
         <module>gdbwriter</module>
         <module>cassandrawriter</module>
         <module>clickhousewriter</module>
-        <!-- common support module -->
+<!--         common support module -->
         <module>plugin-rdbms-util</module>
         <module>plugin-unstructured-storage-util</module>
         <module>hbase20xsqlreader</module>


### PR DESCRIPTION
1.hdfsreader，修复空文件的类型不支持bug
2.eswrite的nested类型不支持数组形式（默认数组全是string），修复
3.eswrite建立mapping时改为不忽略id（修改type为keyword）
4.eswriter的object和geo_shape加入手动解析和匹配数组
5.eswriter传入值为null时出现空指针异常（array和nested下）
6.Json解析失败时改为手动解析，并加入了自动匹配数组代码
7.json内容中出现\解析失败，改成\\
8.json内容中出现 " 解析失败，删除"