### PR TITLE
修复rdbms插件，无法加载plugin.json下配置驱动，导致如虚谷、达梦等数据库连接报错问题

### DIFF
--- a/rdbmsreader/src/main/java/com/alibaba/datax/plugin/reader/rdbmsreader/RdbmsReader.java
+++ b/rdbmsreader/src/main/java/com/alibaba/datax/plugin/reader/rdbmsreader/RdbmsReader.java
@@ -5,6 +5,7 @@ import com.alibaba.datax.common.plugin.RecordSender;
 import com.alibaba.datax.common.spi.Reader;
 import com.alibaba.datax.common.util.Configuration;
 import com.alibaba.datax.plugin.rdbms.reader.CommonRdbmsReader;
+import com.alibaba.datax.plugin.rdbms.util.DBUtil;
 import com.alibaba.datax.plugin.rdbms.util.DBUtilErrorCode;
 import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
 
@@ -12,7 +13,10 @@ import java.util.List;
 
 public class RdbmsReader extends Reader {
     private static final DataBaseType DATABASE_TYPE = DataBaseType.RDBMS;
-
+    static {
+    	//加载插件下面配置的驱动类
+        DBUtil.loadDriverClass("reader", "rdbms");
+    }
     public static class Job extends Reader.Job {
 
         private Configuration originalConfig;

--- a/rdbmswriter/src/main/java/com/alibaba/datax/plugin/reader/rdbmswriter/RdbmsWriter.java
+++ b/rdbmswriter/src/main/java/com/alibaba/datax/plugin/reader/rdbmswriter/RdbmsWriter.java
@@ -4,6 +4,7 @@ import com.alibaba.datax.common.exception.DataXException;
 import com.alibaba.datax.common.plugin.RecordReceiver;
 import com.alibaba.datax.common.spi.Writer;
 import com.alibaba.datax.common.util.Configuration;
+import com.alibaba.datax.plugin.rdbms.util.DBUtil;
 import com.alibaba.datax.plugin.rdbms.util.DBUtilErrorCode;
 import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
 import com.alibaba.datax.plugin.rdbms.writer.CommonRdbmsWriter;
@@ -13,7 +14,10 @@ import java.util.List;
 
 public class RdbmsWriter extends Writer {
     private static final DataBaseType DATABASE_TYPE = DataBaseType.RDBMS;
-
+    static {
+    	//加载插件下面配置的驱动类
+        DBUtil.loadDriverClass("writer", "rdbms");
+    }
     public static class Job extends Writer.Job {
         private Configuration originalConfig = null;
         private CommonRdbmsWriter.Job commonRdbmsWriterMaster;


### PR DESCRIPTION
通过测试验证，发现以前SubCommon*.java不生效的原因是
```		
//在其他代码中调用 new A.B()，不会触发A的static执行	
public class A {
	static {
		System.out.println("AAA");
	}
	
	public static class B {
		public B() {
			System.out.println("B");
		}
	}
}
```