### PR TITLE
replace @table in querySql

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/CommonRdbmsReader.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/CommonRdbmsReader.java
@@ -174,6 +174,7 @@ public class CommonRdbmsReader {
                               TaskPluginCollector taskPluginCollector, int fetchSize) {
             String querySql = readerSliceConfig.getString(Key.QUERY_SQL);
             String table = readerSliceConfig.getString(Key.TABLE);
+            querySql = querySql.replaceAll(Constant.TABLE_NAME_PLACEHOLDER, table);
 
             PerfTrace.getInstance().addTaskDetails(taskId, table + "," + basicMsg);
 

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/CommonRdbmsReader.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/CommonRdbmsReader.java
@@ -172,9 +172,8 @@ public class CommonRdbmsReader {
         public void startRead(Configuration readerSliceConfig,
                               RecordSender recordSender,
                               TaskPluginCollector taskPluginCollector, int fetchSize) {
-            String querySql = readerSliceConfig.getString(Key.QUERY_SQL);
             String table = readerSliceConfig.getString(Key.TABLE);
-            querySql = querySql.replaceAll(Constant.TABLE_NAME_PLACEHOLDER, table);
+            String querySql = readerSliceConfig.getString(Key.QUERY_SQL).replaceAll(Constant.TABLE_NAME_PLACEHOLDER, table);
 
             PerfTrace.getInstance().addTaskDetails(taskId, table + "," + basicMsg);
 


### PR DESCRIPTION
替换querySql中的@table，使得column或者querySql也支持表名读取。在迁移数据的时候可以获取表名来标识数据来源，便于追踪