### PR TITLE
feture: MongoDBReader type 新增json类型

### DIFF
--- a/mongodbreader/doc/mongodbreader.md
+++ b/mongodbreader/doc/mongodbreader.md
@@ -131,6 +131,9 @@ MongoDBReader通过Datax框架从MongoDB并行的读取数据，通过主控的J
 * column：MongoDB的文档列名。【必填】
 * name：Column的名字。【必填】
 * type：Column的类型。【选填】
+    - 基础类型 看 **5 类型转换**
+    - document 嵌套文档字段，通过将`name`设为`nestedDoc.field`格式提取嵌套字段
+    - json 当字段类型为`Document`将字段转为json字符串，仅支持第一层字段
 * splitter：因为MongoDB支持数组类型，但是Datax框架本身不支持数组类型，所以mongoDB读出来的数组类型要通过这个分隔符合并成字符串。【选填】
 * query: MongoDB的额外查询条件。【选填】
 

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/KeyConstant.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/KeyConstant.java
@@ -17,6 +17,11 @@ public class KeyConstant {
      */
     public static final String DOCUMENT_TYPE = "document";
     /**
+     * 与{@link #DOCUMENT_TYPE}一样，都作用于{@link org.bson.Document}，
+     * 但会将字段解析为json，并且不支持提取嵌套字段
+     */
+    public static final String JSON_TYPE = "json";
+    /**
      * mongodb 的 host 地址
      */
     public static final String MONGO_ADDRESS = "address";
@@ -93,5 +98,9 @@ public class KeyConstant {
 
     public static boolean isDocumentType(String type) {
         return type.startsWith(DOCUMENT_TYPE);
+    }
+
+    public static boolean isJsonType(String type) {
+        return type.startsWith(JSON_TYPE);
     }
 }

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
@@ -1,11 +1,5 @@
 package com.alibaba.datax.plugin.reader.mongodbreader;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-
 import com.alibaba.datax.common.element.BoolColumn;
 import com.alibaba.datax.common.element.DateColumn;
 import com.alibaba.datax.common.element.DoubleColumn;
@@ -21,20 +15,27 @@ import com.alibaba.datax.plugin.reader.mongodbreader.util.MongoUtil;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+
 import org.bson.Document;
 import org.bson.types.ObjectId;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Created by jianying.wcj on 2015/3/19 0019.
  * Modified by mingyan.zc on 2016/6/13.
  * Modified by mingyan.zc on 2017/7/5.
+ * Modified by XuDaojie on 2020/09/08.
  */
 public class MongoDBReader extends Reader {
 
@@ -151,7 +152,7 @@ public class MongoDBReader extends Reader {
                     if (tempCol == null) {
                         //continue; 这个不能直接continue会导致record到目的端错位
                         record.addColumn(new StringColumn(null));
-                    }else if (tempCol instanceof Double) {
+                    } else if (tempCol instanceof Double) {
                         //TODO deal with Double.isNaN()
                         record.addColumn(new DoubleColumn((Double) tempCol));
                     } else if (tempCol instanceof Boolean) {
@@ -160,8 +161,14 @@ public class MongoDBReader extends Reader {
                         record.addColumn(new DateColumn((Date) tempCol));
                     } else if (tempCol instanceof Integer) {
                         record.addColumn(new LongColumn((Integer) tempCol));
-                    }else if (tempCol instanceof Long) {
+                    } else if (tempCol instanceof Long) {
                         record.addColumn(new LongColumn((Long) tempCol));
+                    } else  if (tempCol instanceof Document) {
+                        if (KeyConstant.isJsonType(column.getString(KeyConstant.COLUMN_TYPE))) {
+                            record.addColumn(new StringColumn(((Document) tempCol).toJson()));
+                        } else {
+                            record.addColumn(new StringColumn(tempCol.toString()));
+                        }
                     } else {
                         if(KeyConstant.isArrayType(column.getString(KeyConstant.COLUMN_TYPE))) {
                             String splitter = column.getString(KeyConstant.COLUMN_SPLITTER);


### PR DESCRIPTION
1.  mongodbreader type类型新增了可选值 `json`，仅当数据类型为`document`时生效，当值为json时，会输出json字符串
```json
{
  "reader": {
    "name": "mongodbreader",
    "parameter": {
      "address": [
        "127.0.0.1:27017"
      ],
      "userName": "",
      "userPassword": "",
      "dbName": "tag_per_data",
      "collectionName": "tag_data12",
      "column": [
        {
          "name": "unique_id",
          "type": "string"
        },
        // .......
        {
          "name": "account",
          "type": "json"
        }
      ]
    }
  }
}
```
2. document类型依然默认输出 toString()，防止出现新版本与旧版本输出不一致的问题.
发现 #764 的修改里也包含了json类型的支持，看了下代码似乎就有这个兼容问题