### PR TITLE
增加mongoDB 链接配置方式。有些时候目前提供的连接方式不能满足。

### DIFF
--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/KeyConstant.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/KeyConstant.java
@@ -94,4 +94,9 @@ public class KeyConstant {
     public static boolean isDocumentType(String type) {
         return type.startsWith(DOCUMENT_TYPE);
     }
+
+    /**
+     * mongodb url
+     */
+    public static final String MONGO_URL="mongoUrl";
 }

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
@@ -47,6 +47,8 @@ public class MongoDBReader extends Reader {
         private String userName = null;
         private String password = null;
 
+        private String mongoDBUrl = null;
+
         @Override
         public List<Configuration> split(int adviceNumber) {
             return CollectionSplitUtil.doSplit(originalConfig,adviceNumber,mongoClient);
@@ -57,9 +59,12 @@ public class MongoDBReader extends Reader {
             this.originalConfig = super.getPluginJobConf();
             this.userName = originalConfig.getString(KeyConstant.MONGO_USER_NAME, originalConfig.getString(KeyConstant.MONGO_USERNAME));
             this.password = originalConfig.getString(KeyConstant.MONGO_USER_PASSWORD, originalConfig.getString(KeyConstant.MONGO_PASSWORD));
+            this.mongoDBUrl = originalConfig.getString(KeyConstant.MONGO_URL);
             String database =  originalConfig.getString(KeyConstant.MONGO_DB_NAME, originalConfig.getString(KeyConstant.MONGO_DATABASE));
             String authDb =  originalConfig.getString(KeyConstant.MONGO_AUTHDB, database);
-            if(!Strings.isNullOrEmpty(this.userName) && !Strings.isNullOrEmpty(this.password)) {
+            if (!Strings.isNullOrEmpty(mongoDBUrl)) {
+                this.mongoClient = MongoUtil.initMongoClientByURL(mongoDBUrl);
+            }else if(!Strings.isNullOrEmpty(this.userName) && !Strings.isNullOrEmpty(this.password)) {
                 this.mongoClient = MongoUtil.initCredentialMongoClient(originalConfig,userName,password,authDb);
             } else {
                 this.mongoClient = MongoUtil.initMongoClient(originalConfig);
@@ -92,6 +97,8 @@ public class MongoDBReader extends Reader {
         private Object lowerBound = null;
         private Object upperBound = null;
         private boolean isObjectId = true;
+
+        private String mongoDBUrl = null;
 
         @Override
         public void startRead(RecordSender recordSender) {
@@ -189,7 +196,10 @@ public class MongoDBReader extends Reader {
             this.password = readerSliceConfig.getString(KeyConstant.MONGO_USER_PASSWORD, readerSliceConfig.getString(KeyConstant.MONGO_PASSWORD));
             this.database = readerSliceConfig.getString(KeyConstant.MONGO_DB_NAME, readerSliceConfig.getString(KeyConstant.MONGO_DATABASE));
             this.authDb = readerSliceConfig.getString(KeyConstant.MONGO_AUTHDB, this.database);
-            if(!Strings.isNullOrEmpty(userName) && !Strings.isNullOrEmpty(password)) {
+            this.mongoDBUrl = readerSliceConfig.getString(KeyConstant.MONGO_URL);
+            if (!Strings.isNullOrEmpty(mongoDBUrl)) {
+                this.mongoClient = MongoUtil.initMongoClientByURL(mongoDBUrl);
+            } else if(!Strings.isNullOrEmpty(userName) && !Strings.isNullOrEmpty(password)) {
                 mongoClient = MongoUtil.initCredentialMongoClient(readerSliceConfig,userName,password,authDb);
             } else {
                 mongoClient = MongoUtil.initMongoClient(readerSliceConfig);

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/util/MongoUtil.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/util/MongoUtil.java
@@ -11,6 +11,7 @@ import com.alibaba.datax.plugin.reader.mongodbreader.KeyConstant;
 import com.alibaba.datax.plugin.reader.mongodbreader.MongoDBReaderErrorCode;
 
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 
@@ -86,5 +87,18 @@ public class MongoUtil {
             }
         }
         return addressList;
+    }
+
+    public static MongoClient initMongoClientByURL(String mongoUrl) {
+
+        try {
+            return new MongoClient(new MongoClientURI(mongoUrl));
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            throw DataXException.asDataXException(MongoDBReaderErrorCode.ILLEGAL_VALUE, "不合法参数");
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw DataXException.asDataXException(MongoDBReaderErrorCode.UNEXCEPT_EXCEPTION, "未知异常");
+        }
     }
 }


### PR DESCRIPTION
#536 
如这个issues提到的问题，以及mongodb云服务，更倾向于url直接认证的方式。
```
mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
```


https://help.aliyun.com/document_detail/66127.html?spm=a2c4g.11186623.6.572.3f4342c644vl9r
![image](https://user-images.githubusercontent.com/59079269/92721815-3f8d6b80-f399-11ea-9e94-a360eb357d72.png)



