### PR TITLE
CommonRdbmsWriter: 修复将空字符串同步到mysql中tinyint类型列出现的异常

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
@@ -441,11 +441,11 @@ public class CommonRdbmsWriter {
 
                 //tinyint is a little special in some database like mysql {boolean->tinyint(1)}
                 case Types.TINYINT:
-                    Long longValue = column.asLong();
-                    if (null == longValue) {
-                        preparedStatement.setString(columnIndex + 1, null);
+                    String strLongValue = column.asString();
+                    if ((column.getRawData() == null) || (emptyAsNull && "".equals(strLongValue))) {
+                        preparedStatement.setObject(columnIndex + 1, null);
                     } else {
-                        preparedStatement.setString(columnIndex + 1, longValue.toString());
+                        preparedStatement.setLong(columnIndex + 1, column.asLong());
                     }
                     break;
 


### PR DESCRIPTION
当以string类型从csv文件读出空字符串时，无法同步到mysql数据库中nullable的tinyint字段中