### PR TITLE
创建数据库连接，没有释放connection资源的bug

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/OriginalConfPretreatmentUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/OriginalConfPretreatmentUtil.java
@@ -122,7 +122,13 @@ public final class OriginalConfPretreatmentUtil {
                 ListUtil.makeSureNoValueDuplicate(userConfiguredColumns, false);
 
                 // 检查列是否都为数据库表中正确的列（通过执行一次 select column from table 进行判断）
-                DBUtil.getColumnMetaData(connectionFactory.getConnecttion(), oneTable,StringUtils.join(userConfiguredColumns, ","));
+                Connection connection = null;
+                try {
+                    connection = connectionFactory.getConnecttion();
+                    DBUtil.getColumnMetaData(connection, oneTable,StringUtils.join(userConfiguredColumns, ","));
+                } finally {
+                    DBUtil.closeDBResources(null, null, connection);
+                }
             }
         }
     }

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/OriginalConfPretreatmentUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/OriginalConfPretreatmentUtil.java
@@ -122,13 +122,9 @@ public final class OriginalConfPretreatmentUtil {
                 ListUtil.makeSureNoValueDuplicate(userConfiguredColumns, false);
 
                 // 检查列是否都为数据库表中正确的列（通过执行一次 select column from table 进行判断）
-                Connection connection = null;
-                try {
-                    connection = connectionFactory.getConnecttion();
-                    DBUtil.getColumnMetaData(connection, oneTable,StringUtils.join(userConfiguredColumns, ","));
-                } finally {
-                    DBUtil.closeDBResources(null, null, connection);
-                }
+                connection = connectionFactory.getConnecttion();
+                DBUtil.getColumnMetaData(connection, oneTable,StringUtils.join(userConfiguredColumns, ","));
+                DBUtil.closeDBResources(null, null, connection)；
             }
         }
     }


### PR DESCRIPTION
我在测试往mysql里面导数据的时候，发现任务启动后会有2个datax链接一直连着mysql，然后导数据只需要一个connection，后来发现我修改的这个地方，DBUtil.getColumnMetaData以后，并没有释放链接。