### PR TITLE
datax支持es7修改

### DIFF
--- a/elasticsearchwriter/pom.xml
+++ b/elasticsearchwriter/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>io.searchbox</groupId>
             <artifactId>jest-common</artifactId>
-            <version>2.4.0</version>
+            <version>6.3.1</version>
         </dependency>
         <dependency>
             <groupId>io.searchbox</groupId>
             <artifactId>jest</artifactId>
-            <version>2.4.0</version>
+            <version>6.3.1</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESClient.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESClient.java
@@ -16,6 +16,7 @@ import io.searchbox.indices.DeleteIndex;
 import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.aliases.*;
 import io.searchbox.indices.mapping.PutMapping;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeUnit;
  * Created by xiongfeng.bxf on 17/2/8.
  */
 public class ESClient {
+
     private static final Logger log = LoggerFactory.getLogger(ESClient.class);
 
     private JestClient jestClient;
@@ -49,7 +51,6 @@ public class ESClient {
         JestClientFactory factory = new JestClientFactory();
         Builder httpClientConfig = new HttpClientConfig
                 .Builder(endpoint)
-                .setPreemptiveAuth(new HttpHost(endpoint))
                 .multiThreaded(multiThread)
                 .connTimeout(30000)
                 .readTimeout(readTimeout)
@@ -58,8 +59,9 @@ public class ESClient {
                 .discoveryEnabled(discovery)
                 .discoveryFrequency(5l, TimeUnit.MINUTES);
 
-        if (!("".equals(user) || "".equals(passwd))) {
+        if (!(StringUtils.isBlank(user) || StringUtils.isBlank(passwd))) {
             httpClientConfig.defaultCredentials(user, passwd);
+            httpClientConfig.setPreemptiveAuth(HttpHost.create(endpoint));
         }
 
         factory.setHttpClientConfig(httpClientConfig.build());


### PR DESCRIPTION
> 升级searchbox到6.3.1

> datax支持es7修改
`Exception in thread "main" java.lang.IllegalArgumentException: Preemptive authentication set without credentials provider
	at io.searchbox.client.config.HttpClientConfig$Builder.build(HttpClientConfig.java:313)
	at com.alibaba.datax.plugin.writer.elasticsearchwriter.ESClient.createClient(ESClient.java:76)
	at com.alibaba.datax.plugin.writer.elasticsearchwriter.ESClient.main(ESClient.java:45)`







