### PR TITLE
修复rdbms的表字段为关键字无法写入的问题

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/util/DataBaseType.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/util/DataBaseType.java
@@ -168,7 +168,7 @@ public enum DataBaseType {
         }
         StringBuilder builder = new StringBuilder();
         for (String column : columnName) {
-            builder.append(quoteColumnName(column)).append(",");
+            builder.append(column.contains("`") ? column : quoteColumnName(column)).append(",");
         }
         return builder.substring(0, builder.length() - 1);
     }

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/util/DataBaseType.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/util/DataBaseType.java
@@ -1,7 +1,9 @@
 package com.alibaba.datax.plugin.rdbms.util;
 
 import com.alibaba.datax.common.exception.DataXException;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +160,17 @@ public enum DataBaseType {
         }
 
         return result;
+    }
+
+    public String buildQuoteColumnFormat(List<String> columnName) {
+        if (null == columnName || columnName.isEmpty()) {
+            return StringUtils.EMPTY;
+        }
+        StringBuilder builder = new StringBuilder();
+        for (String column : columnName) {
+            builder.append(quoteColumnName(column)).append(",");
+        }
+        return builder.substring(0, builder.length() - 1);
     }
 
     public String quoteTableName(String tableName) {

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
@@ -263,8 +263,9 @@ public class CommonRdbmsWriter {
             this.taskPluginCollector = taskPluginCollector;
 
             // 用于写入数据的时候的类型根据目的表字段类型转换
+            String quoteColumnFormat = this.dataBaseType.buildQuoteColumnFormat(this.columns);
             this.resultSetMetaData = DBUtil.getColumnMetaData(connection,
-                    this.table, StringUtils.join(this.columns, ","));
+                    this.table, quoteColumnFormat);
             // 写数据库的SQL语句
             calcWriteRecordSql();
 

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/WriterUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/WriterUtil.java
@@ -118,6 +118,8 @@ public final class WriterUtil {
                     String.format("您所配置的 writeMode:%s 错误. 因为DataX 目前仅支持replace,update 或 insert 方式. 请检查您的配置并作出修改.", writeMode));
         }
         // && writeMode.trim().toLowerCase().startsWith("replace")
+        String quoteColumnFormat = dataBaseType.buildQuoteColumnFormat(columnHolders);
+
         String writeDataSqlTemplate;
         if (forceUseUpdate ||
                 ((dataBaseType == DataBaseType.MySql || dataBaseType == DataBaseType.Tddl) && writeMode.trim().toLowerCase().startsWith("update"))
@@ -125,7 +127,7 @@ public final class WriterUtil {
             //update只在mysql下使用
 
             writeDataSqlTemplate = new StringBuilder()
-                    .append("INSERT INTO %s (").append(StringUtils.join(columnHolders, ","))
+                    .append("INSERT INTO %s (").append(quoteColumnFormat)
                     .append(") VALUES(").append(StringUtils.join(valueHolders, ","))
                     .append(")")
                     .append(onDuplicateKeyUpdateString(columnHolders))
@@ -137,7 +139,7 @@ public final class WriterUtil {
                 writeMode = "replace";
             }
             writeDataSqlTemplate = new StringBuilder().append(writeMode)
-                    .append(" INTO %s (").append(StringUtils.join(columnHolders, ","))
+                    .append(" INTO %s (").append(quoteColumnFormat)
                     .append(") VALUES(").append(StringUtils.join(valueHolders, ","))
                     .append(")").toString();
         }


### PR DESCRIPTION
使用datax迁移mysql的时候，如果表中的字段使用了mysql关键字（如limit、desc等），会造成迁移目标端写入失败。

这里通过增加 "`"的方式进行了处理，在DataBaseType中新建了buildQuoteColumnFormat方法，方法中使用了DataBaseType原本的quoteColumnName进行了字符串处理，完成修复。

重新编译后使用，能完全修复该问题。