### PR TITLE
修复统计数量不正确的问题。

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
+++ b/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
@@ -155,7 +155,7 @@ public abstract class Channel {
 
         // record为终止对象时，该记录不算入统计数量
         long recordSize = rs.stream().filter(record -> !(record instanceof TerminateRecord)).count();
-        this.statPull(rs.size(), this.getByteSize(rs));
+        this.statPull(recordSize, this.getByteSize(rs));
     }
 
     protected abstract void doPush(Record r);

--- a/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
+++ b/core/src/main/java/com/alibaba/datax/core/transport/channel/Channel.java
@@ -141,13 +141,20 @@ public abstract class Channel {
 
     public Record pull() {
         Record record = this.doPull();
-        this.statPull(1L, record.getByteSize());
+
+        // record为终止对象时，该记录不算入统计数量
+        if (!(record instanceof TerminateRecord)) {
+            this.statPull(1L, record.getByteSize());
+        }
         return record;
     }
 
     public void pullAll(final Collection<Record> rs) {
         Validate.notNull(rs);
         this.doPullAll(rs);
+
+        // record为终止对象时，该记录不算入统计数量
+        long recordSize = rs.stream().filter(record -> !(record instanceof TerminateRecord)).count();
         this.statPull(rs.size(), this.getByteSize(rs));
     }
 


### PR DESCRIPTION
问题原因：终止task的时，会调用this.channel.pushTerminate(TerminateRecord.get())，push一个没有元素的TerminateRecord到queue中，所以pull时，每有1个task统计就会多1个。
在入库时，TerminateRecord会被排除掉，但是在统计时没有处理，引起了该问题。