### PR TITLE
fix json wrong encode

### DIFF
--- a/drdsreader/pom.xml
+++ b/drdsreader/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
 		    <groupId>mysql</groupId>
 		    <artifactId>mysql-connector-java</artifactId>
-		    <version>5.1.34</version>
+		    <version>${mysql.driver.version}</version>
 		</dependency>
 
 

--- a/drdswriter/pom.xml
+++ b/drdswriter/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>${mysql.driver.version}</version>
         </dependency>
     </dependencies>
 

--- a/mysqlreader/pom.xml
+++ b/mysqlreader/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>${mysql.driver.version}</version>
         </dependency>
 
 

--- a/mysqlwriter/pom.xml
+++ b/mysqlwriter/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>${mysql.driver.version}</version>
         </dependency>
 	</dependencies>
 

--- a/plugin-rdbms-util/pom.xml
+++ b/plugin-rdbms-util/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
+            <version>${mysql.driver.version}</version>
             <scope>test</scope>
         </dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+        <mysql.driver.version>5.1.47</mysql.driver.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
https://github.com/alibaba/DataX/issues/390
https://github.com/mysql/mysql-connector-j/pull/9
//Fix for bug #80631 Any ResultSet.getString return garbled result with json type data

// Fix chinese(or other non-ascii encoding) garbled in [mysql 5.7 JSON type]
// Use UTF-8 encoding , because mysql use utf8mb4 for JSON type store ;

https://bugs.mysql.com/bug.php?id=80631
We just need upgrade to 5.1.40+

> ResultSet.getString() sometimes returned garbled data for
> columns of the JSON data type. This was because JSON data
> was binary encoded by MySQL using the utf8mb4 character
> set, but decoded by Connector/J using the ISO-8859-1
> character set. This patch fixes the decoding for JSON
> data. Thanks to Dong Song Ling for contributing to the
> fix.