### PR TITLE
解决txtfilereader读取文本中数据日期类型数据为空字符串时转换错误的问题

### DIFF
--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
@@ -434,7 +434,7 @@ public class UnstructuredStorageReaderUtil {
 							break;
 						case DATE:
 							try {
-								if (columnValue == null) {
+								if(StringUtils.isBlank(columnValue)) {
 									Date date = null;
 									columnGenerated = new DateColumn(date);
 								} else {


### PR DESCRIPTION
解决txtfilereader在读取csv等数据时，如果某一字段如生日设置为date类型，转换格式设置为yyyy-MM-dd，当数据中存在生日数据时候正常，但数据中不存在生日数据时候则报空指针错误。
代码中判断了是否为null，我觉得不够全面，有很多时候比如oracle导出的csv或者其他软件导出的csv可能为空字符串，然后再通过txtfilereader导入就会报空指针的错误，建议空字符串也一并考虑