### PR TITLE
column.asString返回null时使用split方法会报空指针异常

### DIFF
--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESWriter.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESWriter.java
@@ -320,7 +320,7 @@ public class ESWriter extends Writer {
                     String columnName = columnList.get(i).getName();
                     ESFieldType columnType = typeList.get(i);
                     //如果是数组类型，那它传入的必是字符串类型
-                    if (columnList.get(i).isArray() != null && columnList.get(i).isArray()) {
+                    if (columnList.get(i).isArray() != null && columnList.get(i).isArray() && column.asString() != null) {
                         String[] dataList = column.asString().split(splitter);
                         if (!columnType.equals(ESFieldType.DATE)) {
                             data.put(columnName, dataList);


### PR DESCRIPTION
在向ES写数据时，需要用到数组格式。此时会用到String的split对原字符串切割，当源码中的column.asString返回null时使用split方法会报空指针异常。