### PR TITLE
fix #1094: 解决连接泄漏的问题

### DIFF
--- a/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/task/InsertTask.java
+++ b/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/task/InsertTask.java
@@ -65,6 +65,7 @@ public class InsertTask implements Runnable {
 		this.writeRecordSql = writeRecordSql;
 		this.isStop = false;
 		this.deleteMeta = deleteMeta;
+		connHolder.initConnection();
 	}
 	
 	void setWriterTask(ConcurrentTableWriterTask writerTask) {
@@ -151,7 +152,6 @@ public class InsertTask implements Runnable {
 
 	public void doMultiInsert(final List<Record> buffer, final boolean printCost, final long restrict) {
 		checkMemstore();
-		connHolder.initConnection();
 		Connection conn = connHolder.getConn();
 		boolean success = false;
 		long cost = 0;

--- a/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/task/InsertTask.java
+++ b/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/task/InsertTask.java
@@ -165,7 +165,6 @@ public class InsertTask implements Runnable {
 					} catch (InterruptedException e) {
 						LOG.info("thread interrupted ..., ignore");
 					}
-					connHolder.initConnection();
 					conn = connHolder.getConn();
 					LOG.info("retry {}, start do batch insert, size={}", i, buffer.size());
 					checkMemstore();


### PR DESCRIPTION
fix #1094 在doMultiInsert中，每执行一个batch都会创建一个新的连接。可以在构造函数中创建连接，然后在doMultiInsert中直接使用这个连接就可以了。