### PR TITLE
修复obwriter中dbname中有减号'-'时无法写入的问题

### DIFF
--- a/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/ext/ServerConnectInfo.java
+++ b/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/ext/ServerConnectInfo.java
@@ -31,7 +31,7 @@ public class ServerConnectInfo {
 	}
 
 	private void parseJdbcUrl(final String jdbcUrl) {
-		Pattern pattern = Pattern.compile("//([\\w\\.\\-]+:\\d+)/([\\w]+)\\?");
+		Pattern pattern = Pattern.compile("//([\\w\\.\\-]+:\\d+)/([\\w-]+)\\?");
 		Matcher matcher = pattern.matcher(jdbcUrl);
 		if (matcher.find()) {
 			String ipPort = matcher.group(1);


### PR DESCRIPTION
fix the problem that dbname with minus('-') can not be parsed correctly in ob reader.