### PR TITLE
fix(Util): 修复 UnstructuredStorageWriterUtil 中，nullFormat配置不生效的问题

### DIFF
--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/UnstructuredStorageWriterUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/UnstructuredStorageWriterUtil.java
@@ -309,7 +309,11 @@ public class UnstructuredStorageWriterUtil {
                     if (null != column.getRawData()) {
                         boolean isDateColumn = column instanceof DateColumn;
                         if (!isDateColumn) {
-                            splitedRows.add(column.asString());
+                            if(nullFormat.equals(column.asString())) {
+                                splitedRows.add(null);
+                            }else {
+                                splitedRows.add(column.asString());
+                            }
                         } else {
                             if (null != dateParse) {
                                 splitedRows.add(dateParse.format(column


### PR DESCRIPTION
在使用txtFileWriter时，发现配置了nullFormat属性不生效，源数据中的"\N"并没有被替换为空，而是原样输出到了目标文件中，这个commit修复了此问题。