### PR TITLE
修复写入MongoDB时的权限认证bug

### DIFF
--- a/mongodbwriter/src/main/java/com/alibaba/datax/plugin/writer/mongodbwriter/KeyConstant.java
+++ b/mongodbwriter/src/main/java/com/alibaba/datax/plugin/writer/mongodbwriter/KeyConstant.java
@@ -26,6 +26,10 @@ public class KeyConstant {
      */
     public static final String MONGO_DB_NAME = "dbName";
     /**
+     * mongodb 验证数据库
+     */
+    public static final String MONGO_AUTHDB = "authDb";
+    /**
      * mongodb 集合名
      */
     public static final String MONGO_COLLECTION_NAME = "collectionName";


### PR DESCRIPTION
起初mongodbwriter没有添加关于authDb的代码, 导致即使在正确的账号密码下仍然权限认证失败(job.json中的authDb未起作用), 添加相关代码后即可正常写入数据。