### PR TITLE
Hdfsreader-CsvReader-Error

### DIFF
--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/reader/UnstructuredStorageReaderUtil.java
@@ -268,7 +268,6 @@ public class UnstructuredStorageReaderUtil {
 		// .getListConfiguration(Key.COLUMN);
 		List<ColumnEntry> column = UnstructuredStorageReaderUtil
 				.getListColumnEntry(readerSliceConfig, Key.COLUMN);
-		CsvReader csvReader  = null;
 
 		// every line logic
 		try {
@@ -278,17 +277,15 @@ public class UnstructuredStorageReaderUtil {
 				LOG.info(String.format("Header line %s has been skiped.",
 						fetchLine));
 			}
-			csvReader = new CsvReader(reader);
-			csvReader.setDelimiter(fieldDelimiter);
 
-			setCsvReaderConfig(csvReader);
-
-			String[] parseRows;
-			while ((parseRows = UnstructuredStorageReaderUtil
-					.splitBufferedReader(csvReader)) != null) {
+			// write by wangzhuoqun
+			String line;
+			while ((line = reader.readLine()) != null){
+				String[] parseRows = line.split(delimiterInStr);
 				UnstructuredStorageReaderUtil.transportOneRecord(recordSender,
 						column, parseRows, nullFormat, taskPluginCollector);
 			}
+
 		} catch (UnsupportedEncodingException uee) {
 			throw DataXException
 					.asDataXException(
@@ -307,7 +304,6 @@ public class UnstructuredStorageReaderUtil {
 					UnstructuredStorageReaderErrorCode.RUNTIME_EXCEPTION,
 					String.format("运行时异常 : %s", e.getMessage()), e);
 		} finally {
-			csvReader.close();
 			IOUtils.closeQuietly(reader);
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
         <module>gdbreader</module>
         <module>oceanbasev10reader</module>
 
-
         <!-- writer -->
         <module>mysqlwriter</module>
         <module>tdenginewriter</module>
@@ -103,8 +102,6 @@
         <module>clickhousewriter</module>
         <module>oscarwriter</module>
         <module>oceanbasev10writer</module>
-
-
         <!-- common support module -->
         <module>plugin-rdbms-util</module>
         <module>plugin-unstructured-storage-util</module>

--- a/pom.xml
+++ b/pom.xml
@@ -48,60 +48,31 @@
 
         <!-- reader -->
         <module>mysqlreader</module>
-        <module>drdsreader</module>
-        <module>sqlserverreader</module>
-        <module>postgresqlreader</module>
-        <module>kingbaseesreader</module>
         <module>oraclereader</module>
-        <module>odpsreader</module>
-        <module>otsreader</module>
-        <module>otsstreamreader</module>
         <module>txtfilereader</module>
         <module>hdfsreader</module>
         <module>streamreader</module>
-        <module>ossreader</module>
         <module>ftpreader</module>
         <module>mongodbreader</module>
-        <module>rdbmsreader</module>
         <module>hbase11xreader</module>
         <module>hbase094xreader</module>
-        <module>tsdbreader</module>
-        <module>opentsdbreader</module>
-        <module>cassandrareader</module>
-        <module>gdbreader</module>
-        <module>oceanbasev10reader</module>
+
 
         <!-- writer -->
         <module>mysqlwriter</module>
-        <module>tdenginewriter</module>
-        <module>drdswriter</module>
-        <module>odpswriter</module>
         <module>txtfilewriter</module>
         <module>ftpwriter</module>
         <module>hdfswriter</module>
         <module>streamwriter</module>
-        <module>otswriter</module>
         <module>oraclewriter</module>
-        <module>sqlserverwriter</module>
-        <module>postgresqlwriter</module>
-        <module>kingbaseeswriter</module>
-        <module>osswriter</module>
         <module>mongodbwriter</module>
-        <module>adswriter</module>
-        <module>ocswriter</module>
-        <module>rdbmswriter</module>
         <module>hbase11xwriter</module>
         <module>hbase094xwriter</module>
         <module>hbase11xsqlwriter</module>
         <module>hbase11xsqlreader</module>
         <module>elasticsearchwriter</module>
-        <module>tsdbwriter</module>
-        <module>adbpgwriter</module>
-        <module>gdbwriter</module>
-        <module>cassandrawriter</module>
         <module>clickhousewriter</module>
-        <module>oscarwriter</module>
-        <module>oceanbasev10writer</module>
+
         <!-- common support module -->
         <module>plugin-rdbms-util</module>
         <module>plugin-unstructured-storage-util</module>

--- a/pom.xml
+++ b/pom.xml
@@ -48,30 +48,62 @@
 
         <!-- reader -->
         <module>mysqlreader</module>
+        <module>drdsreader</module>
+        <module>sqlserverreader</module>
+        <module>postgresqlreader</module>
+        <module>kingbaseesreader</module>
         <module>oraclereader</module>
+        <module>odpsreader</module>
+        <module>otsreader</module>
+        <module>otsstreamreader</module>
         <module>txtfilereader</module>
         <module>hdfsreader</module>
         <module>streamreader</module>
+        <module>ossreader</module>
         <module>ftpreader</module>
         <module>mongodbreader</module>
+        <module>rdbmsreader</module>
         <module>hbase11xreader</module>
         <module>hbase094xreader</module>
+        <module>tsdbreader</module>
+        <module>opentsdbreader</module>
+        <module>cassandrareader</module>
+        <module>gdbreader</module>
+        <module>oceanbasev10reader</module>
 
 
         <!-- writer -->
         <module>mysqlwriter</module>
+        <module>tdenginewriter</module>
+        <module>drdswriter</module>
+        <module>odpswriter</module>
         <module>txtfilewriter</module>
         <module>ftpwriter</module>
         <module>hdfswriter</module>
         <module>streamwriter</module>
+        <module>otswriter</module>
         <module>oraclewriter</module>
+        <module>sqlserverwriter</module>
+        <module>postgresqlwriter</module>
+        <module>kingbaseeswriter</module>
+        <module>osswriter</module>
         <module>mongodbwriter</module>
+        <module>adswriter</module>
+        <module>ocswriter</module>
+        <module>rdbmswriter</module>
         <module>hbase11xwriter</module>
         <module>hbase094xwriter</module>
         <module>hbase11xsqlwriter</module>
         <module>hbase11xsqlreader</module>
         <module>elasticsearchwriter</module>
+        <module>tsdbwriter</module>
+        <module>adbpgwriter</module>
+        <module>gdbwriter</module>
+        <module>cassandrawriter</module>
         <module>clickhousewriter</module>
+        <module>oscarwriter</module>
+        <module>oceanbasev10writer</module>
+
 
         <!-- common support module -->
         <module>plugin-rdbms-util</module>


### PR DESCRIPTION
hdfsreader use “com.csvreader.CsvReader”. when the column of record is start with ["],the data after ["] will become a big big big recard.
(hdfsreader 使用的com.csvreader.CsvReader类，在读取数据时，如果存在以 " 开头的列，会将其后面的所有数据合并成一个大的字符串）