### PR TITLE
fix odpsreader: specific column is empty

### DIFF
--- a/odpsreader/src/main/java/com/alibaba/datax/plugin/reader/odpsreader/OdpsReader.java
+++ b/odpsreader/src/main/java/com/alibaba/datax/plugin/reader/odpsreader/OdpsReader.java
@@ -505,13 +505,13 @@ public class OdpsReader extends Reader {
                 List<Pair<String, ColumnType>> parsedColumns = new ArrayList<Pair<String, ColumnType>>();
                 for (int i = 0; i < parsedColumnsTmp.size(); i++) {
                     Configuration eachColumnConfig = parsedColumnsTmp.get(i);
-                    String columnName = eachColumnConfig.getString("left");
+                    String columnName = eachColumnConfig.getKeys().iterator().next();
                     ColumnType columnType = ColumnType
-                        .asColumnType(eachColumnConfig.getString("right"));
+                        .asColumnType(eachColumnConfig.getString(columnName).toLowerCase());
                     parsedColumns.add(new MutablePair<String, ColumnType>(
                         columnName, columnType));
-
                 }
+
                 ReaderProxy readerProxy = new ReaderProxy(recordSender, downloadSession,
                         columnTypeMap, parsedColumns, partition, this.isPartitionedTable,
                         start, count, this.isCompress, this.readerSliceConf);


### PR DESCRIPTION
目前master分支及最新release版本（datax_v202205 Latest）从ODPS数据源下载数据时，会报错
com.aliyun.odps.tunnel.TunnelException: ErrorCode=Local Error, ErrorMessage=Specified column list is empty.
原因是代码中解析job json中的column信息有误，可能是用了已废弃的方法。一开始以为是json配置有误，经过不懈的debug才找到原因