### PR TITLE
转义字段列表（防止和系统字段冲突）

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/OriginalConfPretreatmentUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/util/OriginalConfPretreatmentUtil.java
@@ -140,10 +140,14 @@ public final class OriginalConfPretreatmentUtil {
                 for (int i = 0; i < allColumns.size(); i++) {
                     allColumns.set(i, "`" + allColumns.get(i) + "`");
                 }
+                break;
             case SQLServer:
                 for (int i = 0; i < allColumns.size(); i++) {
                     allColumns.set(i, "\"" + allColumns.get(i) + "\"");
                 }
+                break;
+            default:
+                break;
         }
 
         return allColumns;


### PR DESCRIPTION
writer columns为["*"]时，会将*替换成具体的字段，但是由于可能会和系统字段冲突，导致执行失败。所以加上对应数据库类型定义的转义字符