### PR TITLE
升级kudu客户端至1.14.0  修复BUG  新增timestamp类型

### DIFF
--- a/kuduwriter/pom.xml
+++ b/kuduwriter/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.kudu</groupId>
             <artifactId>kudu-client</artifactId>
-            <version>1.11.1</version>
+            <version>1.14.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/kuduwriter/src/main/java/com/q1/datax/plugin/writer/kudu11xwriter/ColumnType.java
+++ b/kuduwriter/src/main/java/com/q1/datax/plugin/writer/kudu11xwriter/ColumnType.java
@@ -15,6 +15,7 @@ public enum ColumnType {
     BIGINT("bigint"),
     DOUBLE("double"),
     BOOLEAN("boolean"),
+    TIMESTAMP("timestamp"),
     LONG("long");
     private String mode;
     ColumnType(String mode) {

--- a/kuduwriter/src/main/java/com/q1/datax/plugin/writer/kudu11xwriter/Kudu11xHelper.java
+++ b/kuduwriter/src/main/java/com/q1/datax/plugin/writer/kudu11xwriter/Kudu11xHelper.java
@@ -55,8 +55,11 @@ public class Kudu11xHelper {
         try {
             String masterAddress = (String) conf.get(Key.KUDU_MASTER);
             kuduClient = new KuduClient.KuduClientBuilder(masterAddress)
-                    .defaultAdminOperationTimeoutMs((Long) conf.get(Key.KUDU_ADMIN_TIMEOUT))
-                    .defaultOperationTimeoutMs((Long) conf.get(Key.KUDU_SESSION_TIMEOUT))
+                    //.defaultAdminOperationTimeoutMs((Long) conf.get(Key.KUDU_ADMIN_TIMEOUT))
+                    //修改从json配置文件中读取kuduwriter的timeout sessionTimeout不能进行数据转换的问题。 java.lang.Integer cannot be cast to java.lang.Long
+                    .defaultAdminOperationTimeoutMs(Long.parseLong(conf.get(Key.KUDU_ADMIN_TIMEOUT).toString()))
+                    //.defaultOperationTimeoutMs((Long) conf.get(Key.KUDU_SESSION_TIMEOUT))
+                    .defaultOperationTimeoutMs(Long.parseLong(conf.get(Key.KUDU_SESSION_TIMEOUT).toString()))
                     .build();
         } catch (Exception e) {
             throw DataXException.asDataXException(Kudu11xWriterErrorcode.GET_KUDU_CONNECTION_ERROR, e);


### PR DESCRIPTION
1. 升级kudu客户端至1.14.0 
2. 修改从json配置文件中读取kuduwriter的timeout sessionTimeout不能进行数据转换的问题。
3. 修复获取布尔值错误
4. 新增支持timestamp类型