### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <commons-lang3-version>3.3.2</commons-lang3-version>
         <commons-configuration-version>1.10</commons-configuration-version>
         <commons-cli-version>1.2</commons-cli-version>
-        <fastjson-version>1.1.46.sec10</fastjson-version>
+        <fastjson-version>1.2.83</fastjson-version>
         <guava-version>16.0.1</guava-version>
         <diamond.version>3.7.2.1-SNAPSHOT</diamond.version>
 

--- a/starrockswriter/pom.xml
+++ b/starrockswriter/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.alibaba.datax</groupId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.75</version>
+            <version>1.2.83</version>
         </dependency>
 		<dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
### What happened？
There are 7 security vulnerabilities found in com.alibaba:fastjson 1.2.28
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)
- [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847)
- [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848)
- [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708)
- [MPS-2020-40828](https://www.oscs1024.com/hd/MPS-2020-40828)
- [MPS-2018-27009](https://www.oscs1024.com/hd/MPS-2018-27009)
- [MPS-2018-27011](https://www.oscs1024.com/hd/MPS-2018-27011)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.28 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS