### PR TITLE
fix(sec): upgrade net.opentsdb:opentsdb to 2.4.1

### DIFF
--- a/opentsdbreader/pom.xml
+++ b/opentsdbreader/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -25,7 +23,7 @@
         <commons-io.version>2.4</commons-io.version>
 
         <!-- opentsdb -->
-        <opentsdb.version>2.3.2</opentsdb.version>
+        <opentsdb.version>2.4.1</opentsdb.version>
 
         <!-- test -->
         <junit4.version>4.13.1</junit4.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in net.opentsdb:opentsdb 2.3.2
- [CVE-2020-35476](https://www.oscs1024.com/hd/CVE-2020-35476)


### What did I do？
Upgrade net.opentsdb:opentsdb from 2.3.2 to 2.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS