### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.16.1

### DIFF
--- a/hbase11xsqlwriter/pom.xml
+++ b/hbase11xsqlwriter/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>datax-all</artifactId>
         <groupId>com.alibaba.datax</groupId>
@@ -18,7 +16,7 @@
         <phoenix.version>4.11.0-HBase-1.1</phoenix.version>
         <hadoop.version>2.7.1</hadoop.version>
         <commons-codec.version>1.8</commons-codec.version>
-        <protobuf.version>3.2.0</protobuf.version>
+        <protobuf.version>3.16.1</protobuf.version>
         <httpclient.version>4.4.1</httpclient.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.protobuf:protobuf-java 3.2.0
- [CVE-2015-5237](https://www.oscs1024.com/hd/CVE-2015-5237)
- [CVE-2021-22569](https://www.oscs1024.com/hd/CVE-2021-22569)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.2.0 to 3.16.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS