### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/postgresqlreader/pom.xml
+++ b/postgresqlreader/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
   			<groupId>org.postgresql</groupId>
   			<artifactId>postgresql</artifactId>
-  			<version>42.3.3</version>
+  			<version>42.4.1</version>
 		</dependency>
 		
     </dependencies>

--- a/postgresqlwriter/pom.xml
+++ b/postgresqlwriter/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.3.3</version>
+			<version>42.4.1</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.3.3
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.3.3 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS