### PR TITLE
FIX 修复通用Rdbms写入时Boolean被转化为String导致某些数据库类型转化错误

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/writer/CommonRdbmsWriter.java
@@ -519,7 +519,7 @@ public class CommonRdbmsWriter {
                     break;
 
                 case Types.BOOLEAN:
-                    preparedStatement.setString(columnIndex + 1, column.asString());
+                    preparedStatement.setBoolean(columnIndex + 1, column.asBoolean());
                     break;
 
                 // warn: bit(1) -> Types.BIT 可使用setBoolean


### PR DESCRIPTION
如数据库为PostgreSQL时，使用通用数据库插件操作，读取数据字段为Boolean，写入数据对应字段也为Boolean，但此时DataX将值转化为String，写入数据库时会导致`column 'xxx' is of type boolean but expression is of type varchar`异常