### PR TITLE
修复taskExecutor失败后，没有正常关闭的问题

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/taskgroup/TaskGroupContainer.java
+++ b/core/src/main/java/com/alibaba/datax/core/taskgroup/TaskGroupContainer.java
@@ -187,8 +187,15 @@ public class TaskGroupContainer extends AbstractContainer {
                     }
             	}
             	
-                // 2.发现该taskGroup下taskExecutor的总状态失败则汇报错误
+                // 2.发现该taskGroup下taskExecutor的总状态失败则汇报错误，同时关闭失败的taskExecutor
                 if (failedOrKilled) {
+
+                    taskFailedExecutorMap.forEach((taskId, taskExecutor) -> {
+                        if (!taskExecutor.isShutdown()) {
+                            taskExecutor.shutdown();
+                        }
+                    });
+
                     lastTaskGroupContainerCommunication = reportTaskGroupCommunication(
                             lastTaskGroupContainerCommunication, taskCountInThisTaskGroup);
 


### PR DESCRIPTION
如果taskExecutor中的ReaderRunner线程报错了，而WriterRunner会卡在MemoryChannel.doPullAll方法的while循环体中，这个taskExecutor会作为失败处理，但是没有shutdown，WriterRunner的线程在进程结束前一直不会释放，如果我们没有调用System.exit()方法，则进程会一直无法结束