### PR TITLE
ElasticSearchClient 支持写入到集群

### DIFF
--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ElasticSearchClient.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ElasticSearchClient.java
@@ -53,6 +53,8 @@ public class ElasticSearchClient {
     public ElasticSearchClient(Configuration conf) {
         this.conf = conf;
         String endpoint = Key.getEndpoint(conf);
+        //es是支持集群写入的
+        String[] endpoints = endpoint.split(",");
         String user = Key.getUsername(conf);
         String passwd = Key.getPassword(conf);
         boolean multiThread = Key.isMultiThread(conf);
@@ -63,7 +65,7 @@ public class ElasticSearchClient {
         int totalConnection = this.conf.getInt("maxTotalConnection", 200);
         JestClientFactory factory = new JestClientFactory();
         Builder httpClientConfig = new HttpClientConfig
-                .Builder(endpoint)
+                .Builder(Arrays.asList(endpoints))
 //                .setPreemptiveAuth(new HttpHost(endpoint))
                 .multiThreaded(multiThread)
                 .connTimeout(readTimeout)


### PR DESCRIPTION
很早的版本是可以写入到集群的，配置大概是endpoint:"xxx,xxx,xxx,xxx"
后来datax更新过突然不支持了，排查发现是后来者没人考虑到配置是集群。
修改如下
<img width="980" alt="image" src="https://user-images.githubusercontent.com/51348093/223403994-40ed3cd9-d300-4968-8501-b1e8118e43e3.png">
