### PR TITLE
Enable mysql auto split

### DIFF
--- a/mysqlreader/src/main/java/com/alibaba/datax/plugin/reader/mysqlreader/MysqlReader.java
+++ b/mysqlreader/src/main/java/com/alibaba/datax/plugin/reader/mysqlreader/MysqlReader.java
@@ -5,6 +5,7 @@ import com.alibaba.datax.common.spi.Reader;
 import com.alibaba.datax.common.util.Configuration;
 import com.alibaba.datax.plugin.rdbms.reader.CommonRdbmsReader;
 import com.alibaba.datax.plugin.rdbms.reader.Constant;
+import com.alibaba.datax.plugin.rdbms.reader.Key;
 import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +31,11 @@ public class MysqlReader extends Reader {
             if (userConfigedFetchSize != null) {
                 LOG.warn("对 mysqlreader 不需要配置 fetchSize, mysqlreader 将会忽略这项配置. 如果您不想再看到此警告,请去除fetchSize 配置.");
             }
-
-            this.originalConfig.set(Constant.FETCH_SIZE, Integer.MIN_VALUE);
+            if("true".equals(this.originalConfig.getString(Key.AUTOSPLIT)) && userConfigedFetchSize != null){
+                this.originalConfig.set(Constant.FETCH_SIZE, userConfigedFetchSize);
+            }else {
+                this.originalConfig.set(Constant.FETCH_SIZE, Integer.MIN_VALUE);
+            }
 
             this.commonRdbmsReaderJob = new CommonRdbmsReader.Job(DATABASE_TYPE);
             this.commonRdbmsReaderJob.init(this.originalConfig);

--- a/mysqlreader/src/main/java/com/alibaba/datax/plugin/reader/mysqlreader/MysqlReader.java
+++ b/mysqlreader/src/main/java/com/alibaba/datax/plugin/reader/mysqlreader/MysqlReader.java
@@ -31,11 +31,7 @@ public class MysqlReader extends Reader {
             if (userConfigedFetchSize != null) {
                 LOG.warn("对 mysqlreader 不需要配置 fetchSize, mysqlreader 将会忽略这项配置. 如果您不想再看到此警告,请去除fetchSize 配置.");
             }
-            if("true".equals(this.originalConfig.getString(Key.AUTOSPLIT)) && userConfigedFetchSize != null){
-                this.originalConfig.set(Constant.FETCH_SIZE, userConfigedFetchSize);
-            }else {
-                this.originalConfig.set(Constant.FETCH_SIZE, Integer.MIN_VALUE);
-            }
+            this.originalConfig.set(Constant.FETCH_SIZE, Integer.MIN_VALUE);
 
             this.commonRdbmsReaderJob = new CommonRdbmsReader.Job(DATABASE_TYPE);
             this.commonRdbmsReaderJob.init(this.originalConfig);

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Constant.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Constant.java
@@ -19,6 +19,10 @@ public final class Constant {
 
     public static String IS_AUTO_SPILT = "isAutoSplit";
 
+    public static String SPLIT_SIZE = "splitSize";
+
+    public static Integer SPLIT_SIZE_DEFAULT = 512*1024;
+
     public final static String FETCH_SIZE = "fetchSize";
 
     public static String QUERY_SQL_TEMPLATE_WITHOUT_WHERE = "select %s from %s ";

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Constant.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Constant.java
@@ -17,6 +17,8 @@ public final class Constant {
 
     public static String IS_TABLE_MODE = "isTableMode";
 
+    public static String IS_AUTO_SPILT = "isAutoSplit";
+
     public final static String FETCH_SIZE = "fetchSize";
 
     public static String QUERY_SQL_TEMPLATE_WITHOUT_WHERE = "select %s from %s ";

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Key.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/Key.java
@@ -11,6 +11,8 @@ public final class Key {
     public final static String PASSWORD = "password";
 
     public final static String TABLE = "table";
+
+    public final static String AUTOSPLIT = "autoSplit";
     
     public final static String MANDATORY_ENCODING = "mandatoryEncoding";
 

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/OriginalConfPretreatmentUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/OriginalConfPretreatmentUtil.java
@@ -58,6 +58,7 @@ public final class OriginalConfPretreatmentUtil {
         //添加自动切分task
         boolean isAutoSplit = recognizeAutoSplit(originalConfig);
         originalConfig.set(Constant.IS_AUTO_SPILT,isAutoSplit);
+
         dealJdbcAndTable(originalConfig);
 
         dealColumnConf(originalConfig);

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/OriginalConfPretreatmentUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/OriginalConfPretreatmentUtil.java
@@ -55,7 +55,9 @@ public final class OriginalConfPretreatmentUtil {
     private static void simplifyConf(Configuration originalConfig) {
         boolean isTableMode = recognizeTableOrQuerySqlMode(originalConfig);
         originalConfig.set(Constant.IS_TABLE_MODE, isTableMode);
-
+        //添加自动切分task
+        boolean isAutoSplit = recognizeAutoSplit(originalConfig);
+        originalConfig.set(Constant.IS_AUTO_SPILT,isAutoSplit);
         dealJdbcAndTable(originalConfig);
 
         dealColumnConf(originalConfig);
@@ -269,4 +271,26 @@ public final class OriginalConfPretreatmentUtil {
         return tableModeFlags.get(0);
     }
 
+    private static boolean recognizeAutoSplit(
+            Configuration originalConfig) {
+        List<Object> conns = originalConfig.getList(Constant.CONN_MARK,
+                Object.class);
+
+        List<Boolean> autoSplitFlags = new ArrayList<Boolean>();
+
+        String autoSplit = null;
+
+        boolean isAutoSplitMode = false;
+        for (int i = 0, len = conns.size(); i < len; i++) {
+            Configuration connConf = Configuration
+                    .from(conns.get(i).toString());
+            autoSplit = connConf.getString(Key.AUTOSPLIT, null);
+
+            isAutoSplitMode = StringUtils.isNotBlank(autoSplit);
+            autoSplitFlags.add(isAutoSplitMode);
+
+        }
+
+        return autoSplitFlags.get(0);
+    }
 }

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/OriginalConfPretreatmentUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/OriginalConfPretreatmentUtil.java
@@ -273,24 +273,11 @@ public final class OriginalConfPretreatmentUtil {
 
     private static boolean recognizeAutoSplit(
             Configuration originalConfig) {
-        List<Object> conns = originalConfig.getList(Constant.CONN_MARK,
-                Object.class);
-
-        List<Boolean> autoSplitFlags = new ArrayList<Boolean>();
-
-        String autoSplit = null;
-
+        String autoSplit = originalConfig.getString(Key.AUTOSPLIT, null);
         boolean isAutoSplitMode = false;
-        for (int i = 0, len = conns.size(); i < len; i++) {
-            Configuration connConf = Configuration
-                    .from(conns.get(i).toString());
-            autoSplit = connConf.getString(Key.AUTOSPLIT, null);
-
-            isAutoSplitMode = StringUtils.isNotBlank(autoSplit);
-            autoSplitFlags.add(isAutoSplitMode);
-
+        if (StringUtils.isNotBlank(autoSplit) && "true".equals(autoSplit)){
+            isAutoSplitMode = true;
         }
-
-        return autoSplitFlags.get(0);
+        return isAutoSplitMode;
     }
 }

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/SingleTableSplitUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/SingleTableSplitUtil.java
@@ -73,7 +73,9 @@ public class SingleTableSplitUtil {
                         splitPkName, "'", DATABASE_TYPE);
             } else if (isLongType) {
                 boolean isAutoSplit = configuration.getBool(Constant.IS_AUTO_SPILT);
-                if (isAutoSplit && configuration.getInt(Constant.FETCH_SIZE) > 10000) {
+                LOG.info("You have set autoSplit={} and fetchSize={}",isAutoSplit,configuration.getInt(Constant.FETCH_SIZE));
+                if (isAutoSplit && configuration.getInt(Constant.FETCH_SIZE) > 20000) {
+                    LOG.info("You have set autoSplit and FetchSize also biger than 20000,AutoSplit is enable.");
                     adviceNum = new BigInteger(minMaxPK.getRight().toString()).divide(new BigInteger(configuration.getInt(Constant.FETCH_SIZE).toString())).intValue() + 1;
                 }
                 rangeList = RdbmsRangeSplitWrap.splitAndWrap(

--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/SingleTableSplitUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/util/SingleTableSplitUtil.java
@@ -73,10 +73,9 @@ public class SingleTableSplitUtil {
                         splitPkName, "'", DATABASE_TYPE);
             } else if (isLongType) {
                 boolean isAutoSplit = configuration.getBool(Constant.IS_AUTO_SPILT);
-                LOG.info("You have set autoSplit={} and fetchSize={}",isAutoSplit,configuration.getInt(Constant.FETCH_SIZE));
-                if (isAutoSplit && configuration.getInt(Constant.FETCH_SIZE) > 20000) {
-                    LOG.info("You have set autoSplit and FetchSize also biger than 20000,AutoSplit is enable.");
-                    adviceNum = new BigInteger(minMaxPK.getRight().toString()).divide(new BigInteger(configuration.getInt(Constant.FETCH_SIZE).toString())).intValue() + 1;
+                LOG.info("You have set autoSplit={} and SplitSize={}",isAutoSplit,configuration.getInt(Constant.SPLIT_SIZE, Constant.SPLIT_SIZE_DEFAULT));
+                if (isAutoSplit) {
+                    adviceNum = new BigInteger(minMaxPK.getRight().toString()).divide(new BigInteger(configuration.getInt(Constant.SPLIT_SIZE,Constant.SPLIT_SIZE_DEFAULT).toString())).intValue() + 1;
                 }
                 rangeList = RdbmsRangeSplitWrap.splitAndWrap(
                         new BigInteger(minMaxPK.getLeft().toString()),

--- a/pom.xml
+++ b/pom.xml
@@ -47,82 +47,82 @@
         <module>transformer</module>
 
         <!-- reader -->
-<!--        <module>mysqlreader</module>-->
-<!--        <module>drdsreader</module>-->
-<!--        <module>sqlserverreader</module>-->
-<!--        <module>postgresqlreader</module>-->
-<!--        <module>kingbaseesreader</module>-->
-<!--        <module>oraclereader</module>-->
-<!--        <module>cassandrareader</module>-->
-<!--        <module>oceanbasev10reader</module>-->
-<!--        <module>rdbmsreader</module>-->
+        <module>mysqlreader</module>
+        <module>drdsreader</module>
+        <module>sqlserverreader</module>
+        <module>postgresqlreader</module>
+        <module>kingbaseesreader</module>
+        <module>oraclereader</module>
+        <module>cassandrareader</module>
+        <module>oceanbasev10reader</module>
+        <module>rdbmsreader</module>
 
-<!--        <module>odpsreader</module>-->
-<!--        <module>otsreader</module>-->
-<!--        <module>otsstreamreader</module>-->
-<!--        <module>hbase11xreader</module>-->
-<!--        <module>hbase094xreader</module>-->
-<!--        <module>hbase11xsqlreader</module>-->
-<!--        <module>hbase20xsqlreader</module>-->
+        <module>odpsreader</module>
+        <module>otsreader</module>
+        <module>otsstreamreader</module>
+        <module>hbase11xreader</module>
+        <module>hbase094xreader</module>
+        <module>hbase11xsqlreader</module>
+        <module>hbase20xsqlreader</module>
 
-<!--        <module>ossreader</module>-->
-<!--        <module>hdfsreader</module>-->
-<!--        <module>ftpreader</module>-->
-<!--        <module>txtfilereader</module>-->
-<!--        <module>streamreader</module>-->
+        <module>ossreader</module>
+        <module>hdfsreader</module>
+        <module>ftpreader</module>
+        <module>txtfilereader</module>
+        <module>streamreader</module>
 
-<!--        <module>mongodbreader</module>-->
-<!--        <module>tdenginereader</module>-->
-<!--        <module>gdbreader</module>-->
-<!--        <module>tsdbreader</module>-->
-<!--        <module>opentsdbreader</module>-->
-<!--        <module>loghubreader</module>-->
-<!--        <module>datahubreader</module>-->
-<!--        <module>starrocksreader</module>-->
+        <module>mongodbreader</module>
+        <module>tdenginereader</module>
+        <module>gdbreader</module>
+        <module>tsdbreader</module>
+        <module>opentsdbreader</module>
+        <module>loghubreader</module>
+        <module>datahubreader</module>
+        <module>starrocksreader</module>
 
-<!--        &lt;!&ndash; writer &ndash;&gt;-->
-<!--        <module>mysqlwriter</module>-->
-<!--        <module>starrockswriter</module>-->
-<!--        <module>drdswriter</module>-->
-<!--        <module>databendwriter</module>-->
-<!--        <module>oraclewriter</module>-->
-<!--        <module>sqlserverwriter</module>-->
-<!--        <module>postgresqlwriter</module>-->
-<!--        <module>kingbaseeswriter</module>-->
-<!--        <module>adswriter</module>-->
-<!--        <module>oceanbasev10writer</module>-->
-<!--        <module>adbpgwriter</module>-->
-<!--        <module>hologresjdbcwriter</module>-->
-<!--        <module>rdbmswriter</module>-->
+        <!-- writer -->
+        <module>mysqlwriter</module>
+        <module>starrockswriter</module>
+        <module>drdswriter</module>
+        <module>databendwriter</module>
+        <module>oraclewriter</module>
+        <module>sqlserverwriter</module>
+        <module>postgresqlwriter</module>
+        <module>kingbaseeswriter</module>
+        <module>adswriter</module>
+        <module>oceanbasev10writer</module>
+        <module>adbpgwriter</module>
+        <module>hologresjdbcwriter</module>
+        <module>rdbmswriter</module>
 
 
-<!--        <module>odpswriter</module>-->
-<!--        <module>osswriter</module>-->
-<!--        <module>otswriter</module>-->
-<!--        <module>hbase11xwriter</module>-->
-<!--        <module>hbase094xwriter</module>-->
-<!--        <module>hbase11xsqlwriter</module>-->
-<!--        <module>hbase20xsqlwriter</module>-->
-<!--        <module>kuduwriter</module>-->
-<!--        <module>ftpwriter</module>-->
-<!--        <module>hdfswriter</module>-->
-<!--        <module>txtfilewriter</module>-->
-<!--        <module>streamwriter</module>-->
+        <module>odpswriter</module>
+        <module>osswriter</module>
+        <module>otswriter</module>
+        <module>hbase11xwriter</module>
+        <module>hbase094xwriter</module>
+        <module>hbase11xsqlwriter</module>
+        <module>hbase20xsqlwriter</module>
+        <module>kuduwriter</module>
+        <module>ftpwriter</module>
+        <module>hdfswriter</module>
+        <module>txtfilewriter</module>
+        <module>streamwriter</module>
 
-<!--        <module>elasticsearchwriter</module>-->
-<!--        <module>mongodbwriter</module>-->
-<!--        <module>tdenginewriter</module>-->
-<!--        <module>ocswriter</module>-->
-<!--        <module>tsdbwriter</module>-->
-<!--        <module>gdbwriter</module>-->
-<!--        <module>oscarwriter</module>-->
-<!--        <module>loghubwriter</module>-->
-<!--        <module>datahubwriter</module>-->
-<!--        <module>cassandrawriter</module>-->
-<!--        <module>clickhousewriter</module>-->
-<!--        <module>doriswriter</module>-->
-<!--        <module>selectdbwriter</module>-->
-<!--        <module>adbmysqlwriter</module>-->
+        <module>elasticsearchwriter</module>
+        <module>mongodbwriter</module>
+        <module>tdenginewriter</module>
+        <module>ocswriter</module>
+        <module>tsdbwriter</module>
+        <module>gdbwriter</module>
+        <module>oscarwriter</module>
+        <module>loghubwriter</module>
+        <module>datahubwriter</module>
+        <module>cassandrawriter</module>
+        <module>clickhousewriter</module>
+        <module>doriswriter</module>
+        <module>selectdbwriter</module>
+        <module>adbmysqlwriter</module>
 
         <!-- common support module -->
         <module>plugin-rdbms-util</module>

--- a/pom.xml
+++ b/pom.xml
@@ -47,82 +47,82 @@
         <module>transformer</module>
 
         <!-- reader -->
-        <module>mysqlreader</module>
-        <module>drdsreader</module>
-        <module>sqlserverreader</module>
-        <module>postgresqlreader</module>
-        <module>kingbaseesreader</module>
-        <module>oraclereader</module>
-        <module>cassandrareader</module>
-        <module>oceanbasev10reader</module>
-        <module>rdbmsreader</module>
+<!--        <module>mysqlreader</module>-->
+<!--        <module>drdsreader</module>-->
+<!--        <module>sqlserverreader</module>-->
+<!--        <module>postgresqlreader</module>-->
+<!--        <module>kingbaseesreader</module>-->
+<!--        <module>oraclereader</module>-->
+<!--        <module>cassandrareader</module>-->
+<!--        <module>oceanbasev10reader</module>-->
+<!--        <module>rdbmsreader</module>-->
 
-        <module>odpsreader</module>
-        <module>otsreader</module>
-        <module>otsstreamreader</module>
-        <module>hbase11xreader</module>
-        <module>hbase094xreader</module>
-        <module>hbase11xsqlreader</module>
-        <module>hbase20xsqlreader</module>
+<!--        <module>odpsreader</module>-->
+<!--        <module>otsreader</module>-->
+<!--        <module>otsstreamreader</module>-->
+<!--        <module>hbase11xreader</module>-->
+<!--        <module>hbase094xreader</module>-->
+<!--        <module>hbase11xsqlreader</module>-->
+<!--        <module>hbase20xsqlreader</module>-->
 
-        <module>ossreader</module>
-        <module>hdfsreader</module>
-        <module>ftpreader</module>
-        <module>txtfilereader</module>
-        <module>streamreader</module>
+<!--        <module>ossreader</module>-->
+<!--        <module>hdfsreader</module>-->
+<!--        <module>ftpreader</module>-->
+<!--        <module>txtfilereader</module>-->
+<!--        <module>streamreader</module>-->
 
-        <module>mongodbreader</module>
-        <module>tdenginereader</module>
-        <module>gdbreader</module>
-        <module>tsdbreader</module>
-        <module>opentsdbreader</module>
-        <module>loghubreader</module>
-        <module>datahubreader</module>
-        <module>starrocksreader</module>
+<!--        <module>mongodbreader</module>-->
+<!--        <module>tdenginereader</module>-->
+<!--        <module>gdbreader</module>-->
+<!--        <module>tsdbreader</module>-->
+<!--        <module>opentsdbreader</module>-->
+<!--        <module>loghubreader</module>-->
+<!--        <module>datahubreader</module>-->
+<!--        <module>starrocksreader</module>-->
 
-        <!-- writer -->
-        <module>mysqlwriter</module>
-        <module>starrockswriter</module>
-        <module>drdswriter</module>
-        <module>databendwriter</module>
-        <module>oraclewriter</module>
-        <module>sqlserverwriter</module>
-        <module>postgresqlwriter</module>
-        <module>kingbaseeswriter</module>
-        <module>adswriter</module>
-        <module>oceanbasev10writer</module>
-        <module>adbpgwriter</module>
-        <module>hologresjdbcwriter</module>
-        <module>rdbmswriter</module>
+<!--        &lt;!&ndash; writer &ndash;&gt;-->
+<!--        <module>mysqlwriter</module>-->
+<!--        <module>starrockswriter</module>-->
+<!--        <module>drdswriter</module>-->
+<!--        <module>databendwriter</module>-->
+<!--        <module>oraclewriter</module>-->
+<!--        <module>sqlserverwriter</module>-->
+<!--        <module>postgresqlwriter</module>-->
+<!--        <module>kingbaseeswriter</module>-->
+<!--        <module>adswriter</module>-->
+<!--        <module>oceanbasev10writer</module>-->
+<!--        <module>adbpgwriter</module>-->
+<!--        <module>hologresjdbcwriter</module>-->
+<!--        <module>rdbmswriter</module>-->
 
 
-        <module>odpswriter</module>
-        <module>osswriter</module>
-        <module>otswriter</module>
-        <module>hbase11xwriter</module>
-        <module>hbase094xwriter</module>
-        <module>hbase11xsqlwriter</module>
-        <module>hbase20xsqlwriter</module>
-        <module>kuduwriter</module>
-        <module>ftpwriter</module>
-        <module>hdfswriter</module>
-        <module>txtfilewriter</module>
-        <module>streamwriter</module>
+<!--        <module>odpswriter</module>-->
+<!--        <module>osswriter</module>-->
+<!--        <module>otswriter</module>-->
+<!--        <module>hbase11xwriter</module>-->
+<!--        <module>hbase094xwriter</module>-->
+<!--        <module>hbase11xsqlwriter</module>-->
+<!--        <module>hbase20xsqlwriter</module>-->
+<!--        <module>kuduwriter</module>-->
+<!--        <module>ftpwriter</module>-->
+<!--        <module>hdfswriter</module>-->
+<!--        <module>txtfilewriter</module>-->
+<!--        <module>streamwriter</module>-->
 
-        <module>elasticsearchwriter</module>
-        <module>mongodbwriter</module>
-        <module>tdenginewriter</module>
-        <module>ocswriter</module>
-        <module>tsdbwriter</module>
-        <module>gdbwriter</module>
-        <module>oscarwriter</module>
-        <module>loghubwriter</module>
-        <module>datahubwriter</module>
-        <module>cassandrawriter</module>
-        <module>clickhousewriter</module>
-        <module>doriswriter</module>
-        <module>selectdbwriter</module>
-        <module>adbmysqlwriter</module>
+<!--        <module>elasticsearchwriter</module>-->
+<!--        <module>mongodbwriter</module>-->
+<!--        <module>tdenginewriter</module>-->
+<!--        <module>ocswriter</module>-->
+<!--        <module>tsdbwriter</module>-->
+<!--        <module>gdbwriter</module>-->
+<!--        <module>oscarwriter</module>-->
+<!--        <module>loghubwriter</module>-->
+<!--        <module>datahubwriter</module>-->
+<!--        <module>cassandrawriter</module>-->
+<!--        <module>clickhousewriter</module>-->
+<!--        <module>doriswriter</module>-->
+<!--        <module>selectdbwriter</module>-->
+<!--        <module>adbmysqlwriter</module>-->
 
         <!-- common support module -->
         <module>plugin-rdbms-util</module>


### PR DESCRIPTION
when use mysql reader and need split table ,we should set SplitFactor,If a large table has a large amount of data, the amount of SplitFactor based on configuration information may need to be adjusted manually, which may cause excessive pressure on the database when the data is shred. Refer to FlinkCDC's shred idea. autoSplit and splitSize can be used to roughly split data, greatly reducing the pressure on the database side,the splitSize defualt 512*1024,and user can set it in json too. 
                                                                                                                                 from 南京贝登医疗股份有限公司数据开发putin