### PR TITLE
mongodb读取支持json序列化

### DIFF
--- a/mongodbreader/doc/mongodbreader.md
+++ b/mongodbreader/doc/mongodbreader.md
@@ -10,116 +10,120 @@ MongoDBReader通过Datax框架从MongoDB并行的读取数据，通过主控的J
 #### 3 功能说明
 * 该示例从MongoDB读一份数据到ODPS。
 
-	    {
-	    "job": {
-	        "setting": {
-	            "speed": {
-	                "channel": 2
-	            }
-	        },
-	        "content": [
-	            {
-	                "reader": {
-	                    "name": "mongodbreader",
-	                    "parameter": {
-	                        "address": ["127.0.0.1:27017"],
-	                        "userName": "",
-	                        "userPassword": "",
-	                        "dbName": "tag_per_data",
-	                        "collectionName": "tag_data12",
-	                        "column": [
-	                            {
-	                                "name": "unique_id",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "sid",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "user_id",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "auction_id",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "content_type",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "pool_type",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "frontcat_id",
-	                                "type": "Array",
-	                                "spliter": ""
-	                            },
-	                            {
-	                                "name": "categoryid",
-	                                "type": "Array",
-	                                "spliter": ""
-	                            },
-	                            {
-	                                "name": "gmt_create",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "taglist",
-	                                "type": "Array",
-	                                "spliter": " "
-	                            },
-	                            {
-	                                "name": "property",
-	                                "type": "string"
-	                            },
-	                            {
-	                                "name": "scorea",
-	                                "type": "int"
-	                            },
-	                            {
-	                                "name": "scoreb",
-	                                "type": "int"
-	                            },
-	                            {
-	                                "name": "scorec",
-	                                "type": "int"
-	                            }
-	                        ]
-	                    }
-	                },
-	                "writer": {
-	                    "name": "odpswriter",
-	                    "parameter": {
-	                        "project": "tb_ai_recommendation",
-	                        "table": "jianying_tag_datax_read_test01",
-	                        "column": [
-	                            "unique_id",
-	                            "sid",
-	                            "user_id",
-	                            "auction_id",
-	                            "content_type",
-	                            "pool_type",
-	                            "frontcat_id",
-	                            "categoryid",
-	                            "gmt_create",
-	                            "taglist",
-	                            "property",
-	                            "scorea",
-	                            "scoreb"
-	                        ],
-	                        "accessId": "**************",
-	                        "accessKey": "********************",
-	                        "truncate": true,
-	                        "odpsServer": "xxx/api",
-	                        "tunnelServer": "xxx"
-	                    }
-	                }
-	            }
-	        ]
-	    }
+        {
+        "job": {
+            "setting": {
+                "speed": {
+                    "channel": 2
+                }
+            },
+            "content": [
+                {
+                    "reader": {
+                        "name": "mongodbreader",
+                        "parameter": {
+                            "address": ["127.0.0.1:27017"],
+                            "userName": "",
+                            "userPassword": "",
+                            "dbName": "tag_per_data",
+                            "collectionName": "tag_data12",
+                            "column": [
+                                {
+                                    "name": "unique_id",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "sid",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "user_id",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "auction_id",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "content_type",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "pool_type",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "frontcat_id",
+                                    "type": "Array",
+                                    "spliter": ""
+                                },
+                                {
+                                    "name": "categoryid",
+                                    "type": "Array",
+                                    "spliter": ""
+                                },
+                                {
+                                    "name": "gmt_create",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "taglist",
+                                    "type": "Array",
+                                    "spliter": " "
+                                },
+                                {
+                                    "name": "property",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "scorea",
+                                    "type": "int"
+                                },
+                                {
+                                    "name": "scoreb",
+                                    "type": "int"
+                                },
+                                {
+                                    "name": "scorec",
+                                    "type": "int"
+                                },
+                                {
+                                    "name": "appid_list",
+                                    "type": "json"
+                                }
+                            ]
+                        }
+                    },
+                    "writer": {
+                        "name": "odpswriter",
+                        "parameter": {
+                            "project": "tb_ai_recommendation",
+                            "table": "jianying_tag_datax_read_test01",
+                            "column": [
+                                "unique_id",
+                                "sid",
+                                "user_id",
+                                "auction_id",
+                                "content_type",
+                                "pool_type",
+                                "frontcat_id",
+                                "categoryid",
+                                "gmt_create",
+                                "taglist",
+                                "property",
+                                "scorea",
+                                "scoreb"
+                            ],
+                            "accessId": "**************",
+                            "accessKey": "********************",
+                            "truncate": true,
+                            "odpsServer": "xxx/api",
+                            "tunnelServer": "xxx"
+                        }
+                    }
+                }
+            ]
+        }
         }
 #### 4 参数说明
 
@@ -133,17 +137,18 @@ MongoDBReader通过Datax框架从MongoDB并行的读取数据，通过主控的J
 * type：Column的类型。【选填】
 * splitter：因为MongoDB支持数组类型，但是Datax框架本身不支持数组类型，所以mongoDB读出来的数组类型要通过这个分隔符合并成字符串。【选填】
 * query: MongoDB的额外查询条件。【选填】
-
+* json：因为MongoDB支持子文档和数组类型子文档，但是Datax框架本身不支持，所以mongoDB读出来的数据通过JSON序列化成字符串。
 #### 5 类型转换
 
-| DataX 内部类型| MongoDB 数据类型    |
-| -------- | -----  |
-| Long     | int, Long |
-| Double   | double |
-| String   | string, array |
-| Date     | date  |
-| Boolean  | boolean |
-| Bytes    | bytes |
+| DataX 内部类型 | MongoDB 数据类型  |
+|------------|---------------|
+| Long       | int, Long     |
+| Double     | double        |
+| String     | string, array |
+| Date       | date          |
+| Boolean    | boolean       |
+| Bytes      | bytes         |
+| Object     | json          |
 
 
 #### 6 性能报告

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/mongodbreader/MongoDBReader.java
@@ -173,6 +173,8 @@ public class MongoDBReader extends Reader {
                                 String tempArrayStr = Joiner.on(splitter).join(array);
                                 record.addColumn(new StringColumn(tempArrayStr));
                             }
+                        }else if ("json".equalsIgnoreCase(column.getString("type"))) {
+                            record.addColumn(new StringColumn(JSON.toJSONString(tempCol)));
                         } else {
                             record.addColumn(new StringColumn(tempCol.toString()));
                         }


### PR DESCRIPTION
你好，这是一个关于datax同步mongodb的提交。
在此之前，datax不支持序列化子文档或数组类型的子文档，
会直接toString为Document的字符，这导致在写入配置时存在不便之处。
我对datax进行了改进，现在它支持了json序列化。
我们相信这个改进对于datax用户来说是非常有用的，我们希望审核者能够认可并接受这个改进。谢谢！
配置示例：
"column": [
              {
                "name": "appid_list",
                "type": "json"
              }]