### PR TITLE
fix(sec): upgrade com.jcraft:jsch to 0.1.54

### DIFF
--- a/ftpreader/pom.xml
+++ b/ftpreader/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.51</version>
+			<version>0.1.54</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-net</groupId>

--- a/ftpwriter/pom.xml
+++ b/ftpwriter/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.51</version>
+			<version>0.1.54</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-net</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.jcraft:jsch 0.1.51
- [CVE-2016-5725](https://www.oscs1024.com/hd/CVE-2016-5725)


### What did I do？
Upgrade com.jcraft:jsch from 0.1.51 to 0.1.54 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS