### PR TITLE
fix(sec): upgrade org.apache.zookeeper:zookeeper to 3.4.14

### DIFF
--- a/hbase094xreader/pom.xml
+++ b/hbase094xreader/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.3.2</version>
+            <version>3.5.5</version>
         </dependency>
 
 

--- a/hbase094xwriter/pom.xml
+++ b/hbase094xwriter/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.3.2</version>
+            <version>3.5.5</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in org.apache.zookeeper:zookeeper 3.3.2
- [CVE-2019-0201](https://www.oscs1024.com/hd/CVE-2019-0201)
- [CVE-2014-0085](https://www.oscs1024.com/hd/CVE-2014-0085)
- [CVE-2018-8012](https://www.oscs1024.com/hd/CVE-2018-8012)


### What did I do？
Upgrade org.apache.zookeeper:zookeeper from 3.3.2 to 3.4.14 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS