### PR TITLE
修复hbase11xreader和hbase11xwriter指定字段类型为boolean、short、int、long、float、double时的问题

### DIFF
--- a/hbase11xreader/src/main/java/com/alibaba/datax/plugin/reader/hbase11xreader/HbaseAbstractTask.java
+++ b/hbase11xreader/src/main/java/com/alibaba/datax/plugin/reader/hbase11xreader/HbaseAbstractTask.java
@@ -92,22 +92,22 @@ public abstract class HbaseAbstractTask {
         Column column;
         switch (columnType) {
             case BOOLEAN:
-                column = new BoolColumn(ArrayUtils.isEmpty(byteArray) ? null : Bytes.toBoolean(byteArray));
+                column = new BoolColumn(ArrayUtils.isEmpty(byteArray) ? null : Boolean.valueOf(Bytes.toString(byteArray)));
                 break;
             case SHORT:
-                column = new LongColumn(ArrayUtils.isEmpty(byteArray) ? null : String.valueOf(Bytes.toShort(byteArray)));
+                column = new LongColumn(ArrayUtils.isEmpty(byteArray) ? null : Bytes.toString(byteArray));
                 break;
             case INT:
-                column = new LongColumn(ArrayUtils.isEmpty(byteArray) ? null : Bytes.toInt(byteArray));
+                column = new LongColumn(ArrayUtils.isEmpty(byteArray) ? null : Integer.valueOf(Bytes.toString(byteArray)));
                 break;
             case LONG:
-                column = new LongColumn(ArrayUtils.isEmpty(byteArray) ? null : Bytes.toLong(byteArray));
+                column = new LongColumn(ArrayUtils.isEmpty(byteArray) ? null : Long.valueOf(Bytes.toString(byteArray)));
                 break;
             case FLOAT:
-                column = new DoubleColumn(ArrayUtils.isEmpty(byteArray) ? null : Bytes.toFloat(byteArray));
+                column = new DoubleColumn(ArrayUtils.isEmpty(byteArray) ? null : Float.valueOf(Bytes.toString(byteArray)));
                 break;
             case DOUBLE:
-                column = new DoubleColumn(ArrayUtils.isEmpty(byteArray) ? null : Bytes.toDouble(byteArray));
+                column = new DoubleColumn(ArrayUtils.isEmpty(byteArray) ? null : Double.valueOf(Bytes.toString(byteArray)));
                 break;
             case STRING:
                 column = new StringColumn(ArrayUtils.isEmpty(byteArray) ? null : new String(byteArray, encoding));

--- a/hbase11xwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xwriter/HbaseAbstractTask.java
+++ b/hbase11xwriter/src/main/java/com/alibaba/datax/plugin/writer/hbase11xwriter/HbaseAbstractTask.java
@@ -90,22 +90,22 @@ public abstract class HbaseAbstractTask {
         if(column.getRawData() != null){
             switch (columnType) {
                 case INT:
-                    bytes = Bytes.toBytes(column.asLong().intValue());
+                    bytes = Bytes.toBytes(String.valueOf(column.asLong().intValue()));
                     break;
                 case LONG:
-                    bytes = Bytes.toBytes(column.asLong());
+                    bytes = Bytes.toBytes(String.valueOf(column.asLong()));
                     break;
                 case DOUBLE:
-                    bytes = Bytes.toBytes(column.asDouble());
+                    bytes = Bytes.toBytes(String.valueOf(column.asDouble()));
                     break;
                 case FLOAT:
-                    bytes = Bytes.toBytes(column.asDouble().floatValue());
+                    bytes = Bytes.toBytes(String.valueOf(column.asDouble().floatValue()));
                     break;
                 case SHORT:
-                    bytes = Bytes.toBytes(column.asLong().shortValue());
+                    bytes = Bytes.toBytes(String.valueOf(column.asLong().shortValue()));
                     break;
                 case BOOLEAN:
-                    bytes = Bytes.toBytes(column.asBoolean());
+                    bytes = Bytes.toBytes(String.valueOf(column.asBoolean()));
                     break;
                 case STRING:
                     bytes = this.getValueByte(columnType,column.asString());

--- a/oraclereader/doc/oraclereader.md
+++ b/oraclereader/doc/oraclereader.md
@@ -194,7 +194,7 @@ OracleReader插件实现了从Oracle读取数据。在底层实现上，OracleRe
 
 * **where**
 
-	* 描述：筛选条件，MysqlReader根据指定的column、table、where条件拼接SQL，并根据这个SQL进行数据抽取。在实际业务场景中，往往会选择当天的数据进行同步，可以将where条件指定为gmt_create > $bizdate 。注意：不可以将where条件指定为limit 10，limit不是SQL的合法where子句。<br />
+	* 描述：筛选条件，OracleReader根据指定的column、table、where条件拼接SQL，并根据这个SQL进行数据抽取。在实际业务场景中，往往会选择当天的数据进行同步，可以将where条件指定为gmt_create > $bizdate 。注意：不可以将where条件指定为limit 10，limit不是SQL的合法where子句。<br />
 
           where条件可以有效地进行业务增量同步。
 


### PR DESCRIPTION
（1）修复hbase11xreader插件指定字段类型为boolean、short、int、long、float、double时转换失败问题，例如，当指定字段类型为int时，会报错："exception":"offset (0)+Length (4)exceed the capacity of the array:1"。
（2）修复hbase11xwriter插件指定字段类型为boolean、short、int、long、float、double时目标端写入乱码问题，当指定目标端字段类型为boolean、short、int、long、float、double，写入hbase会出现乱码问题。
（3）oraclereader md文档描述错误改正。
