### PR TITLE
fix(sec): upgrade org.xerial:sqlite-jdbc to 3.41.2.2

### DIFF
--- a/odpsreader/pom.xml
+++ b/odpsreader/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.34.0</version>
+			<version>3.41.2.2</version>
 		</dependency>
 
 		<!-- ref:http://odps.alibaba-inc.com/doc/prddoc/odps_sdk_v2/sdk.html -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.xerial:sqlite-jdbc 3.34.0
- [CVE-2023-32697](https://www.oscs1024.com/hd/CVE-2023-32697)


### What did I do？
Upgrade org.xerial:sqlite-jdbc from 3.34.0 to 3.41.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS