### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
-        <mysql.driver.version>5.1.47</mysql.driver.version>
+        <mysql.driver.version>8.0.28</mysql.driver.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in mysql:mysql-connector-java 5.1.47
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)
- [CVE-2021-2471](https://www.oscs1024.com/hd/CVE-2021-2471)
- [CVE-2018-3258](https://www.oscs1024.com/hd/CVE-2018-3258)
- [CVE-2019-2692](https://www.oscs1024.com/hd/CVE-2019-2692)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.47 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS