### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-core to 1.2.1

### DIFF
--- a/hbase094xreader/pom.xml
+++ b/hbase094xreader/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-core</artifactId>
-            <version>0.20.205.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/hbase094xwriter/pom.xml
+++ b/hbase094xwriter/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-core</artifactId>
-            <version>0.20.205.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.apache.hadoop:hadoop-core 0.20.205.0
- [CVE-2013-2192](https://www.oscs1024.com/hd/CVE-2013-2192)
- [CVE-2012-4449](https://www.oscs1024.com/hd/CVE-2012-4449)


### What did I do？
Upgrade org.apache.hadoop:hadoop-core from 0.20.205.0 to 1.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS