### PR TITLE
fix(sec): upgrade commons-codec:commons-codec to 1.13

### DIFF
--- a/hbase094xwriter/pom.xml
+++ b/hbase094xwriter/pom.xml
@@ -14,7 +14,7 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <commons-codec.version>1.8</commons-codec.version>
+        <commons-codec.version>1.13</commons-codec.version>
     </properties>
 
     <dependencies>

--- a/hbase11xsqlwriter/pom.xml
+++ b/hbase11xsqlwriter/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <phoenix.version>4.11.0-HBase-1.1</phoenix.version>
         <hadoop.version>2.7.1</hadoop.version>
-        <commons-codec.version>1.8</commons-codec.version>
+        <commons-codec.version>1.13</commons-codec.version>
         <protobuf.version>3.2.0</protobuf.version>
         <httpclient.version>4.4.1</httpclient.version>
     </properties>

--- a/hbase20xsqlwriter/pom.xml
+++ b/hbase20xsqlwriter/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <phoenix.version>5.2.5-HBase-2.x</phoenix.version>
-        <commons-codec.version>1.8</commons-codec.version>
+        <commons-codec.version>1.13</commons-codec.version>
     </properties>
 
     <dependencies>

--- a/odpsreader/pom.xml
+++ b/odpsreader/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.8</version>
+			<version>1.13</version>
 		</dependency>
 	</dependencies>
 

--- a/odpswriter/pom.xml
+++ b/odpswriter/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
+            <version>1.13</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-codec:commons-codec 1.8
- [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853)


### What did I do？
Upgrade commons-codec:commons-codec from 1.8 to 1.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS