### PR TITLE
[transformer] 使用stringbuilder替换stringbuffer

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/transport/transformer/GroovyTransformer.java
+++ b/core/src/main/java/com/alibaba/datax/core/transport/transformer/GroovyTransformer.java
@@ -66,7 +66,7 @@ public class GroovyTransformer extends Transformer {
 
 
     private String getGroovyRule(String expression, List<String> extraPackagesStrList) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if(extraPackagesStrList!=null) {
             for (String extraPackagesStr : extraPackagesStrList) {
                 if (StringUtils.isNotEmpty(extraPackagesStr)) {


### PR DESCRIPTION
对于函数中的非共享变量，使用StringBuilder而不是stringBuffer