### PR TITLE
fix(sec): upgrade org.apache.httpcomponents:httpclient to 4.5.13

### DIFF
--- a/opentsdbreader/pom.xml
+++ b/opentsdbreader/pom.xml
@@ -21,7 +21,7 @@
         <commons-lang3.version>3.3.2</commons-lang3.version>
 
         <!-- http -->
-        <httpclient.version>4.5</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <commons-io.version>2.4</commons-io.version>
 
         <!-- opentsdb -->


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.apache.httpcomponents:httpclient 4.5
- [CVE-2020-13956](https://www.oscs1024.com/hd/CVE-2020-13956)
- [MPS-2022-12292](https://www.oscs1024.com/hd/MPS-2022-12292)


### What did I do？
Upgrade org.apache.httpcomponents:httpclient from 4.5 to 4.5.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS