### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-hdfs to 3.3.2

### DIFF
--- a/hbase11xreader/pom.xml
+++ b/hbase11xreader/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <hbase.version>1.1.3</hbase.version>
-        <hadoop.version>2.5.0</hadoop.version>
+        <hadoop.version>3.3.2</hadoop.version>
     </properties>
 
     <dependencies>

--- a/hbase11xwriter/pom.xml
+++ b/hbase11xwriter/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <hbase.version>1.1.3</hbase.version>
-        <hadoop.version>2.5.0</hadoop.version>
+        <hadoop.version>3.3.2</hadoop.version>
         <commons-codec.version>1.8</commons-codec.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 7 security vulnerabilities found in org.apache.hadoop:hadoop-hdfs 2.5.0
- [CVE-2018-1296](https://www.oscs1024.com/hd/CVE-2018-1296)
- [MPS-2022-12474](https://www.oscs1024.com/hd/MPS-2022-12474)
- [CVE-2012-3376](https://www.oscs1024.com/hd/CVE-2012-3376)
- [CVE-2017-3161](https://www.oscs1024.com/hd/CVE-2017-3161)
- [CVE-2017-3162](https://www.oscs1024.com/hd/CVE-2017-3162)
- [CVE-2016-5001](https://www.oscs1024.com/hd/CVE-2016-5001)
- [MPS-2022-12484](https://www.oscs1024.com/hd/MPS-2022-12484)


### What did I do？
Upgrade org.apache.hadoop:hadoop-hdfs from 2.5.0 to 3.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS