### PR TITLE
fix(sec): upgrade org.apache.httpcomponents:httpclient to 4.5.13

### DIFF
--- a/starrockswriter/pom.xml
+++ b/starrockswriter/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.fastjson2</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.httpcomponents:httpclient 4.5.3
- [CVE-2020-13956](https://www.oscs1024.com/hd/CVE-2020-13956)


### What did I do？
Upgrade org.apache.httpcomponents:httpclient from 4.5.3 to 4.5.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS