### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/cassandrareader/pom.xml
+++ b/cassandrareader/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
+			<version>32.0.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/ftpreader/pom.xml
+++ b/ftpreader/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
+			<version>32.0.0-jre</version>
 		</dependency>
 
 		<dependency>

--- a/ftpwriter/pom.xml
+++ b/ftpwriter/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
+			<version>32.0.0-jre</version>
 		</dependency>
 
 		<dependency>

--- a/mongodbreader/pom.xml
+++ b/mongodbreader/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
         </dependency>
     </dependencies>
 

--- a/mongodbwriter/pom.xml
+++ b/mongodbwriter/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.datax</groupId>

--- a/ocswriter/pom.xml
+++ b/ocswriter/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
         </dependency>
     </dependencies>
 

--- a/odpsreader/pom.xml
+++ b/odpsreader/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.xerial</groupId>

--- a/ossreader/pom.xml
+++ b/ossreader/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>com.aliyun.oss</groupId>

--- a/osswriter/pom.xml
+++ b/osswriter/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.aliyun.oss</groupId>

--- a/plugin-unstructured-storage-util/pom.xml
+++ b/plugin-unstructured-storage-util/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
+			<version>32.0.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.javacsv</groupId>

--- a/streamreader/pom.xml
+++ b/streamreader/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/txtfilereader/pom.xml
+++ b/txtfilereader/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/txtfilewriter/pom.xml
+++ b/txtfilewriter/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>32.0.0-jre</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.guava:guava 16.0.1
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)
- [CVE-2020-8908](https://www.oscs1024.com/hd/CVE-2020-8908)


### What did I do？
Upgrade com.google.guava:guava from 16.0.1 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS