### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/adbmysqlwriter/pom.xml
+++ b/adbmysqlwriter/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.40</version>
+            <version>8.0.28</version>
         </dependency>
 	</dependencies>
 

--- a/oceanbasev10reader/pom.xml
+++ b/oceanbasev10reader/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.40</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in mysql:mysql-connector-java 5.1.40
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)
- [CVE-2021-2471](https://www.oscs1024.com/hd/CVE-2021-2471)
- [CVE-2017-3523](https://www.oscs1024.com/hd/CVE-2017-3523)
- [CVE-2017-3586](https://www.oscs1024.com/hd/CVE-2017-3586)
- [CVE-2018-3258](https://www.oscs1024.com/hd/CVE-2018-3258)
- [CVE-2019-2692](https://www.oscs1024.com/hd/CVE-2019-2692)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.40 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS