### PR TITLE
升级HDFS,增加HDFS读取parquet的能力

### DIFF
--- a/hdfsreader/pom.xml
+++ b/hdfsreader/pom.xml
@@ -13,7 +13,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
-        <hive.version>1.1.1</hive.version>
+        <hive.version>3.1.3</hive.version>
         <hadoop.version>2.7.1</hadoop.version>
     </properties>
     <dependencies>
@@ -128,9 +128,10 @@
             <version>1.12.0</version>
         </dependency>
         <dependency>
+<!--            2.3.0升级为2.9.0,因为maven废弃了2.3.0-->
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-format</artifactId>
-            <version>2.3.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
@@ -146,6 +147,12 @@
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop</artifactId>
             <version>1.12.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.twitter/parquet-tools -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-tools</artifactId>
+            <version>1.8.1</version>
         </dependency>
 
     </dependencies>

--- a/hdfswriter/pom.xml
+++ b/hdfswriter/pom.xml
@@ -14,7 +14,7 @@
     <description>HdfsWriter提供了写入HDFS功能。</description>
     <packaging>jar</packaging>
     <properties>
-        <hive.version>1.1.1</hive.version>
+        <hive.version>3.1.3</hive.version>
         <hadoop.version>2.7.1</hadoop.version>
     </properties>
 
@@ -112,6 +112,11 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>parquet-hadoop-bundle</artifactId>
+            <version>1.6.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
在9月份的更新中，公告说明了支持hdfs reader 和writer支持parquet.这导致了一大波用户开始使用hdfsreader读取parquet文件。
但是我观察9月份的pr和issues还有代码改动，发现改动内容不是hdfs,在pr区域搜索到一个2020年的关于支持parquet的读取能力的代码
[2020年的PR:DATAX插件HdfsReader支持parquet格式，功能提交](https://github.com/alibaba/DataX/pull/584)
和最新的代码对比，发现DFSUtil类中，关于parquet的逻辑丢失了。
<img width="1292" alt="image" src="https://github.com/alibaba/DataX/assets/51348093/6079edc3-9edf-49af-bce9-033af0c8dc0d">
<img width="1358" alt="image" src="https://github.com/alibaba/DataX/assets/51348093/c83f3cc6-82e1-454f-8cd9-2763b2160d4b">
所以本地PR内容：

- 增加处理parquet文件的能力
- 升级一些maven仓库废弃的版本依赖。

本PR感谢[felix-thinkingdata](https://github.com/felix-thinkingdata)
[felix.wang](https://github.com/felix-thinkingdata)提供的代码和QQ用户916203112的测试。本人只做了代码冲突解决和版本升级方便合并的工作。
