### PR TITLE
issue #1962 修复gaussdbwriter打包后ClassNotFoundException的错误

### DIFF
--- a/gaussdbwriter/src/main/java/com/alibaba/datax/plugin/writer/gaussdbwriter/GaussDbWriter.java
+++ b/gaussdbwriter/src/main/java/com/alibaba/datax/plugin/writer/gaussdbwriter/GaussDbWriter.java
@@ -1,4 +1,4 @@
-package com.alibaba.datax.plugin.reader.gaussdbwriter;
+package com.alibaba.datax.plugin.writer.gaussdbwriter;
 
 import com.alibaba.datax.common.exception.DataXException;
 import com.alibaba.datax.common.plugin.RecordReceiver;


### PR DESCRIPTION
changes:
- modified folder name "gaussdbwriter/src/main/java/com/alibaba/datax/plugin/reader" to  "gaussdbwriter/src/main/java/com/alibaba/datax/plugin/writer"
- modified first line of file GaussDbWriter.java, corrected the package name from "reader" to "writer"

related issue #1962