### PR TITLE
fix bug: Missing artifact org.apache parquet:parquet-format:jar:2.3.0

### DIFF
--- a/hdfsreader/pom.xml
+++ b/hdfsreader/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-format</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
fix bug #1966
解决源码打包，仓库无相关插件的问题，升级hdfsreader项目下的parquet-format依赖至2.3.1