### PR TITLE
fix(postgresqlreader): Add missed 'column' field in template

### DIFF
--- a/postgresqlreader/src/main/resources/plugin_job_template.json
+++ b/postgresqlreader/src/main/resources/plugin_job_template.json
@@ -1,6 +1,7 @@
 {
     "name": "postgresqlreader",
     "parameter": {
+        "column": [],
         "username": "",
         "password": "",
         "connection": [


### PR DESCRIPTION
This job template misses a 'column' field, when I generate the template with datax.py and fill it in, I get an error about it.