### PR TITLE
fix(SqlWriter): set null value to NULL in SqlWriter

### DIFF
--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/SqlWriter.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/SqlWriter.java
@@ -58,7 +58,7 @@ public class SqlWriter implements UnstructuredWriter {
         int capacity = 18 + tableName.length() + sb.length();
         this.insertPrefix = new StringBuilder(capacity);
         this.insertPrefix
-                .append("INSERT INTO ").append("`").append(tableName).append("`").append(" (").append(sb).append(")").append(" VALUES(");
+                .append("INSERT INTO ").append(quoteChar).append(tableName).append(quoteChar).append(" (").append(sb).append(")").append(" VALUES(");
     }
 
     public void appendCommit() throws IOException {

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/SqlWriter.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/SqlWriter.java
@@ -22,7 +22,7 @@ public class SqlWriter implements UnstructuredWriter {
         this.sqlWriter = writer;
         this.quoteChar = quoteChar;
         this.lineSeparator = lineSeparator;
-        this.tableName = tableName;
+        this.tableName = quoteChar + tableName + quoteChar;
         this.nullFormat = nullFormat;
         buildInsertPrefix(columnNames);
     }
@@ -55,10 +55,9 @@ public class SqlWriter implements UnstructuredWriter {
             sb.append(quoteChar).append(columnName).append(quoteChar);
         }
 
-        int capacity = 18 + tableName.length() + sb.length();
+        int capacity = 16 + tableName.length() + sb.length();
         this.insertPrefix = new StringBuilder(capacity);
-        this.insertPrefix
-                .append("INSERT INTO ").append(quoteChar).append(tableName).append(quoteChar).append(" (").append(sb).append(")").append(" VALUES(");
+        this.insertPrefix.append("INSERT INTO ").append(tableName).append(" (").append(sb).append(")").append(" VALUES(");
     }
 
     public void appendCommit() throws IOException {

--- a/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/UnstructuredStorageWriterUtil.java
+++ b/plugin-unstructured-storage-util/src/main/java/com/alibaba/datax/plugin/unstructuredstorage/writer/UnstructuredStorageWriterUtil.java
@@ -283,7 +283,8 @@ public class UnstructuredStorageWriterUtil {
             String lineSeparator = config.getString(Key.LINE_DELIMITER, IOUtils.LINE_SEPARATOR);
             List<String> headers = config.getList(Key.HEADER, String.class);
             Preconditions.checkArgument(CollectionUtils.isNotEmpty(headers), "column names are empty");
-            unstructuredWriter = new SqlWriter(writer, quoteChar, tableName, lineSeparator, headers);
+            String nullFormat = config.getString(Key.NULL_FORMAT, Constant.DEFAULT_NULL_FORMAT);
+            unstructuredWriter = new SqlWriter(writer, quoteChar, tableName, lineSeparator, headers, nullFormat);
         }
 
         return unstructuredWriter;


### PR DESCRIPTION
When transfer data with SqlWriter, the null value would be written as `nullFormat`. This could work in CsvWriter, but will lead to this situation: 
If I have a numeric column c1 with some values being null, and I set `nullFormat` to '\N'. In this case, it will be output as `insert into xx (c1) values ('\N');`. This is a wrong sql which can not be executed. I originally hoped to get `insert into xx (c1) values NULL;`

Fixed the bug in this PR.