### PR TITLE
fix CommonRdbmsReader 读取BIT类型将 null 错误识别为 false

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/CommonRdbmsReader.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/reader/CommonRdbmsReader.java
@@ -313,7 +313,13 @@ public class CommonRdbmsReader {
                     // warn: bit(>1) -> Types.VARBINARY 可使用BytesColumn
                     case Types.BOOLEAN:
                     case Types.BIT:
-                        record.addColumn(new BoolColumn(rs.getBoolean(i)));
+                        // rs.getBoolean 将 null 错误识别为 false，当对象为 null时，单独处理
+                        Object bitValue = rs.getObject(i);
+                        if (bitValue == null) {
+                            record.addColumn(new BoolColumn());
+                        } else {
+                            record.addColumn(new BoolColumn(rs.getBoolean(i)));
+                        }
                         break;
 
                     case Types.NULL:


### PR DESCRIPTION
目前已知源端是 sqlserver 或 mysql，若表字段为 bit，且允许为空，值有3种：null/true/false 或者 null/1/0，
但在 rs.getBoolean 会将 null 错误识别为 false，导致数据不一致，故添加 null 的处理逻辑