### PR TITLE
升级parquet-format 到2.3.1

### DIFF
--- a/hdfsreader/pom.xml
+++ b/hdfsreader/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-format</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
本地编译的时候，一直报找不到parquet-format 2.3.0版本的错误。
去maven官方仓库看了一下，发现此版本已经不支持了。 
所以升级到2.3.1版本，避免新环境在本地打包过程中出现问题。
![image](https://github.com/alibaba/DataX/assets/26269682/6aabddc8-ec3e-4241-a204-64440e183c7b)
