### PR TITLE
fix bug : 3.9.6 版本的maven打包失败问题修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2-beta-3</version>
                 <configuration>
                     <finalName>datax</finalName>
                     <descriptors>


### PR DESCRIPTION
issue #2021 
原因：`3.9.6`版本的`maven`默认的`maven-assembly-plugin`插件版本为`3.6.0`，[maven默认插件版本](https://maven.apache.org/plugins/)
`assembly` _goal_ 已经废弃
```shell
mvn org.apache.maven.plugins:maven-assembly-plugin:help
```
输出：
```
[INFO] --- assembly:3.6.0:help (default-cli) @ standalone-pom ---
[INFO] Apache Maven Assembly Plugin 3.6.0
  A Maven plugin to create archives of your project's sources, classes,
  dependencies etc. from flexible assembly descriptors.

This plugin has 2 goals:

assembly:help
  Display help information on maven-assembly-plugin.
  Call mvn assembly:help -Ddetail=true -Dgoal=<goal-name> to display parameter
  details.

assembly:single
  Assemble an application bundle or distribution from an assembly descriptor.
  This goal is suitable either for binding to the lifecycle or calling directly
  from the command line (provided all required files are available before the
  build starts, or are produced by another goal specified before this one on the
  command line).
  Note that the parameters descriptors, descriptorRefs, and
  descriptorSourceDirectory are disjoint, i.e., they are not combined during
  descriptor location calculation.
```

由于根目录下的`package.xml`中 **XSD**版本为`1.1.0`:
```xml
<assembly
        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
...
```
结合[官方的依赖关系](https://maven.apache.org/plugins/maven-assembly-plugin/)，指定版本为 **`2.2-beta-3`**:
```xml
https://maven.apache.org/xsd/assembly-1.1.0.xsd, https://maven.apache.org/xsd/component-1.1.0.xsd (for version 2.2-beta-1 - 2.2-beta-3)
```