### PR TITLE
fix: Fix Comfiguration类中checkPath方法未生效的问题

### DIFF
--- a/common/src/main/java/com/alibaba/datax/common/util/Configuration.java
+++ b/common/src/main/java/com/alibaba/datax/common/util/Configuration.java
@@ -1047,7 +1047,7 @@ public class Configuration {
 					"系统编程错误, 该异常代表系统编程错误, 请联系DataX开发团队!.");
 		}
 
-		for (final String each : StringUtils.split(".")) {
+		for (final String each : StringUtils.split(path, ".")) {
 			if (StringUtils.isBlank(each)) {
 				throw new IllegalArgumentException(String.format(
 						"系统编程错误, 路径[%s]不合法, 路径层次之间不能出现空白字符 .", path));


### PR DESCRIPTION
 checkPath的方法逻辑是将path按照"."分割，然后判断路径层次之间不能出现空白字符，但误写成了将"."使用空格分割(Null separator means use whitespace)，因此这段代码永远不会抛出异常。