### PR TITLE
Feat: 支持kafkawriter插件

### DIFF
--- a/datax-example/datax-example-kafka/pom.xml
+++ b/datax-example/datax-example-kafka/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.datax</groupId>
+        <artifactId>datax-example</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>datax-example-kafka</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>datax-example-core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>streamreader</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>kafkawriter</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/datax-example/datax-example-kafka/src/test/java/com/alibaba/datax/example/kafka/KafkaTest.java
+++ b/datax-example/datax-example-kafka/src/test/java/com/alibaba/datax/example/kafka/KafkaTest.java
@@ -1,0 +1,15 @@
+package com.alibaba.datax.example.kafka;
+
+import com.alibaba.datax.example.ExampleContainer;
+import com.alibaba.datax.example.util.PathUtil;
+import org.junit.Test;
+
+
+public class KafkaTest {
+    @Test
+    public void testStreamReader2KafkaWriter() {
+        String path = "/stream2kafka.json";
+        String jobPath = PathUtil.getAbsolutePathFromClassPath(path);
+        ExampleContainer.start(jobPath);
+    }
+}

--- a/datax-example/datax-example-kafka/src/test/resources/stream2kafka.json
+++ b/datax-example/datax-example-kafka/src/test/resources/stream2kafka.json
@@ -1,0 +1,49 @@
+{
+  "job": {
+    "content": [
+      {
+        "reader": {
+          "name": "streamreader",
+          "parameter": {
+            "sliceRecordCount": 10,
+            "column": [
+              {
+                "type": "long",
+                "value": "10"
+              },
+              {
+                "type": "string",
+                "value": "hello，你好，世界-DataX"
+              },
+              {
+                "type": "date",
+                "value": "2014-07-07 00:00:00"
+              }
+            ]
+          }
+        },
+        "writer": {
+          "name": "kafkawriter",
+          "parameter": {
+            "bootstrapServers": "10.0.0.11:9092",
+            "topic": "ods_stream_test",
+            "keyIndex": 0,
+            "column": [
+              "id",
+              "content",
+              "date"
+            ],
+            "props": {
+              "acks": "1"
+            }
+          }
+        }
+      }
+    ],
+    "setting": {
+      "speed": {
+        "channel": 1
+      }
+    }
+  }
+}

--- a/datax-example/pom.xml
+++ b/datax-example/pom.xml
@@ -15,6 +15,7 @@
         <module>datax-example-core</module>
         <module>datax-example-streamreader</module>
         <module>datax-example-neo4j</module>
+        <module>datax-example-kafka</module>
     </modules>
 
     <properties>

--- a/kafkawriter/doc/kafkawriter.md
+++ b/kafkawriter/doc/kafkawriter.md
@@ -1,0 +1,87 @@
+### Datax MongoDBWriter
+
+#### 1 快速介绍
+
+KafkaWriter 插件利用java kafka-clients创建消息生产者Producer<String, String>
+进行Kafka消息发送操作。通过配置keys定义数据字段名，将消息组装成json格式，使用lz4进行压缩。
+
+#### 2 实现原理
+
+KafkaWriter 插件利用java kafka-clients创建消息生产者Producer<String, String>进行Kafka消息发送操作
+
+#### 3 功能说明
+
+* 该示例从Mysql读一份数据发送到Kafka的配置。
+
+```json
+{
+  "job": {
+    "content": [
+      {
+        "reader": {
+          "name": "streamreader",
+          "parameter": {
+            "sliceRecordCount": 10,
+            "column": [
+              {
+                "type": "long",
+                "value": "10"
+              },
+              {
+                "type": "string",
+                "value": "hello，你好，世界-DataX"
+              },
+              {
+                "type": "date",
+                "value": "2014-07-07 00:00:00"
+              }
+            ]
+          }
+        },
+        "writer": {
+          "name": "kafkawriter",
+          "parameter": {
+            "bootstrapServers": "10.0.0.11:9092",
+            "topic": "ods_stream_test",
+            "keyIndex": 0,
+            "column": [
+              "id",
+              "content",
+              "date"
+            ],
+            "props": {
+              "acks": "1"
+            }
+          }
+        }
+      }
+    ],
+    "setting": {
+      "speed": {
+        "channel": 1
+      }
+    }
+  }
+}
+```
+
+#### 4 参数说明
+
+* bootstrapServers： kafka中心bootstrapServers地址。【必填】【默认值：无】
+* topic：发送消息的主题。【必填】【默认值：无】
+* column： 组装json数据的属性字段。【必填】【默认值：无】
+
+#### 5 类型转换
+
+| DataX 内部类型 | Kafka 数据类型 |
+|------------|------------|
+| Long       | String     |
+| Double     | String     |
+| String     | String     |
+| Date       | String     |
+| Boolean    | String     |
+| Bytes      | String     |
+
+#### 6 性能报告
+
+#### 7 测试报告

--- a/kafkawriter/doc/kafkawriter.md
+++ b/kafkawriter/doc/kafkawriter.md
@@ -1,4 +1,4 @@
-### Datax MongoDBWriter
+### Datax KafkaWriter
 
 #### 1 快速介绍
 
@@ -11,7 +11,7 @@ KafkaWriter 插件利用java kafka-clients创建消息生产者Producer<String, 
 
 #### 3 功能说明
 
-* 该示例从Mysql读一份数据发送到Kafka的配置。
+* 该示例从streamreader生成10行数据发送到Kafka的配置。
 
 ```json
 {
@@ -70,6 +70,7 @@ KafkaWriter 插件利用java kafka-clients创建消息生产者Producer<String, 
 * bootstrapServers： kafka中心bootstrapServers地址。【必填】【默认值：无】
 * topic：发送消息的主题。【必填】【默认值：无】
 * column： 组装json数据的属性字段。【必填】【默认值：无】
+* props： Kafka自定义参数。【选填】【默认值：无】
 
 #### 5 类型转换
 

--- a/kafkawriter/pom.xml
+++ b/kafkawriter/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.datax</groupId>
+        <artifactId>datax-all</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>kafkawriter</artifactId>
+    <name>kafkawriter</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>datax-common</artifactId>
+            <version>${datax-project-version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.5.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- compiler plugin -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${jdk-version}</source>
+                    <target>${jdk-version}</target>
+                    <encoding>${project-sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <!-- assembly plugin -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/package.xml</descriptor>
+                    </descriptors>
+                    <finalName>datax</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>dwzip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kafkawriter/src/main/assembly/package.xml
+++ b/kafkawriter/src/main/assembly/package.xml
@@ -1,0 +1,35 @@
+<assembly
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id></id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>plugin.json</include>
+                <include>plugin_job_template.json</include>
+            </includes>
+            <outputDirectory>plugin/writer/kafkawriter</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>target/</directory>
+            <includes>
+                <include>kafkawriter-0.0.1-SNAPSHOT.jar</include>
+            </includes>
+            <outputDirectory>plugin/writer/kafkawriter</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>plugin/writer/kafkawriter/libs</outputDirectory>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/kafkawriter/src/main/java/com/alibaba/datax/plugin/writer/kafkawriter/KafkaWriter.java
+++ b/kafkawriter/src/main/java/com/alibaba/datax/plugin/writer/kafkawriter/KafkaWriter.java
@@ -1,0 +1,160 @@
+package com.alibaba.datax.plugin.writer.kafkawriter;
+
+import com.alibaba.datax.common.element.Column;
+import com.alibaba.datax.common.element.Record;
+import com.alibaba.datax.common.plugin.RecordReceiver;
+import com.alibaba.datax.common.spi.Writer;
+import com.alibaba.datax.common.util.Configuration;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaWriter extends Writer {
+
+    public static final String PARAMETER_BOOTSTRAP_SERVERS = "bootstrapServers";
+    public static final String PARAMETER_TOPIC = "topic";
+    public static final String PARAMETER_COLUMN = "column";
+    public static final String PARAMETER_KEY_INDEX = "keyIndex";
+    public static final String PARAMETER_PROPS = "props";
+
+    public static class Job extends Writer.Job {
+        private static final Logger log = LoggerFactory.getLogger(Job.class);
+
+        private Configuration conf = null;
+
+        @Override
+        public void init() {
+            this.conf = super.getPluginJobConf();
+            log.debug("kafka writer job conf:{}", this.conf.toJSON());
+            this.conf.getNecessaryValue(PARAMETER_BOOTSTRAP_SERVERS, KafkaWriterError.KAFKA_CONN_BOOTSTRAP_SERVERS_MISSING);
+            this.conf.getNecessaryValue(PARAMETER_TOPIC, KafkaWriterError.KAFKA_CONN_TOPIC_MISSING);
+            this.conf.getNecessaryValue(PARAMETER_COLUMN, KafkaWriterError.KAFKA_COLUMN_MISSING);
+        }
+
+        @Override
+        public void prepare() {
+        }
+
+        @Override
+        public List<Configuration> split(int mandatoryNumber) {
+            List<Configuration> configList = new ArrayList<>();
+            for (int i = 0; i < mandatoryNumber; i++) {
+                configList.add(this.conf.clone());
+            }
+            return configList;
+        }
+
+        @Override
+        public void post() {
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+    public static class Task extends Writer.Task {
+        private static final Logger log = LoggerFactory.getLogger(Task.class);
+
+        private Configuration conf = null;
+        private Producer<String, String> producer;
+
+        private String topic;
+        private List<String> columns;
+        private int keyIndex = -1;
+
+        @Override
+        public void init() {
+            this.conf = super.getPluginJobConf();
+            topic = this.conf.getString(PARAMETER_TOPIC);
+            columns = this.conf.getList(PARAMETER_COLUMN, String.class);
+            keyIndex = this.conf.getInt(PARAMETER_KEY_INDEX, -1);
+
+            if (keyIndex >= columns.size()) {
+                log.warn("key index out of range, keyIndex:{}", keyIndex);
+                keyIndex = -1;
+            }
+
+            Map<String, Object> props = new HashMap<>();
+            props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, this.conf.getString(PARAMETER_BOOTSTRAP_SERVERS));
+
+            props.put(ProducerConfig.ACKS_CONFIG, "all");
+            props.put(ProducerConfig.RETRIES_CONFIG, 0);
+            props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+            props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
+            props.put(ProducerConfig.LINGER_MS_CONFIG, 1);
+            props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
+
+            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+            Map<String, Object> customizeProps = this.conf.getMap(PARAMETER_PROPS, Object.class);
+            if (null != customizeProps) {
+                props.putAll(customizeProps);
+            }
+
+            producer = new KafkaProducer<>(props);
+
+        }
+
+        @Override
+        public void prepare() {
+        }
+
+        @Override
+        public void startWrite(RecordReceiver lineReceiver) {
+            log.info("start to writer kafka.");
+
+            Record record;
+            while ((record = lineReceiver.getFromReader()) != null) {
+                String key = null;
+                if (keyIndex >= 0) {
+                    Column column = record.getColumn(keyIndex);
+                    Object rawData = column.getRawData();
+                    if (null != rawData) {
+                        key = JSON.toJSONString(rawData);
+                    }
+                }
+
+                String value = recordToJson(record);
+                ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topic, key, value);
+
+                log.debug("send data. key: {}, value: {}", key, value);
+                producer.send(producerRecord);
+            }
+        }
+
+        @Override
+        public void post() {
+        }
+
+        @Override
+        public void destroy() {
+            if (producer != null) {
+                producer.close();
+            }
+        }
+
+        private String recordToJson(Record record) {
+            final int size = columns.size();
+            final Map<String, String> data = new HashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                final Column column = record.getColumn(i);
+                data.put(columns.get(i), column.asString());
+            }
+            return JSON.toJSONString(data, JSONWriter.Feature.WriteMapNullValue);
+        }
+    }
+}

--- a/kafkawriter/src/main/java/com/alibaba/datax/plugin/writer/kafkawriter/KafkaWriterError.java
+++ b/kafkawriter/src/main/java/com/alibaba/datax/plugin/writer/kafkawriter/KafkaWriterError.java
@@ -1,0 +1,31 @@
+package com.alibaba.datax.plugin.writer.kafkawriter;
+
+import com.alibaba.datax.common.spi.ErrorCode;
+
+/**
+ * @author tanghaiyang
+ */
+public enum KafkaWriterError implements ErrorCode {
+    KAFKA_CONN_BOOTSTRAP_SERVERS_MISSING("KAFKA_CONN_BOOTSTRAP_SERVERS_MISSING", "Kafka broker地址错误，请检查填写的broker地址是否正确"),
+    KAFKA_CONN_TOPIC_MISSING("KAFKA_CONN_TOPIC_MISSING", "请检查Kafka topic配置是否正确"),
+    KAFKA_COLUMN_MISSING("KAFKA_COLUMN_MISSING", "请检查Kafka字段配置是否正确"),
+    ;
+
+    private final String code;
+    private final String desc;
+
+    KafkaWriterError(String code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.desc;
+    }
+}

--- a/kafkawriter/src/main/resources/plugin.json
+++ b/kafkawriter/src/main/resources/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "kafkawriter",
+  "class": "com.alibaba.datax.plugin.writer.kafkawriter.KafkaWriter",
+  "description": "将数据通过Kafka生产者写入指定topic",
+  "developer": "hy"
+}

--- a/kafkawriter/src/main/resources/plugin_job_template.json
+++ b/kafkawriter/src/main/resources/plugin_job_template.json
@@ -1,0 +1,14 @@
+{
+  "name": "kafkawriter",
+  "parameter": {
+    "bootstrapServers": "this is bootstrapServers",
+    "topic": "this is send topic",
+    "column": [
+      "id",
+      "name"
+    ],
+    "props": {
+      "acks": "all"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,9 @@
         <module>adbmysqlwriter</module>
         <module>sybasewriter</module>
         <module>neo4jwriter</module>
+
+        <module>kafkawriter</module>
+
         <!-- common support module -->
         <module>plugin-rdbms-util</module>
         <module>plugin-unstructured-storage-util</module>


### PR DESCRIPTION
基于： org.apache.kafka:kafka-clients:2.5.1

配置示例：
```
{
  "job": {
    "content": [
      {
        "reader": {
          "name": "streamreader",
          "parameter": {
            "sliceRecordCount": 10,
            "column": [
              {
                "type": "long",
                "value": "10"
              },
              {
                "type": "string",
                "value": "hello，你好，世界-DataX"
              },
              {
                "type": "date",
                "value": "2014-07-07 00:00:00"
              }
            ]
          }
        },
        "writer": {
          "name": "kafkawriter",
          "parameter": {
            "bootstrapServers": "localhost:9092",
            "topic": "ods_stream_test",
            "keyIndex": 0,
            "column": [ // json对象字段
              "id",
              "content",
              "date"
            ],
            "props": {  // kafka配置参数
              "acks": "1"
            }
          }
        }
      }
    ],
    "setting": {
      "speed": {
        "channel": 1
      }
    }
  }
}
```

Kafka消息：
key: 10
value: {"date":"2014-07-07 00:00:00","content":"hello，你好，世界-DataX","id":"10"}