### PR TITLE
fix: 修复TaskMonitor在多TaskGroupContainer情况下可能会出现的taskid冲突问题

### DIFF
--- a/core/src/main/java/com/alibaba/datax/core/taskgroup/TaskGroupContainer.java
+++ b/core/src/main/java/com/alibaba/datax/core/taskgroup/TaskGroupContainer.java
@@ -58,7 +58,7 @@ public class TaskGroupContainer extends AbstractContainer {
      */
     private String taskCollectorClass;
 
-    private TaskMonitor taskMonitor = TaskMonitor.getInstance();
+    private TaskMonitor taskMonitor = new TaskMonitor();
 
     public TaskGroupContainer(Configuration configuration) {
         super(configuration);

--- a/core/src/main/java/com/alibaba/datax/core/taskgroup/TaskMonitor.java
+++ b/core/src/main/java/com/alibaba/datax/core/taskgroup/TaskMonitor.java
@@ -16,16 +16,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TaskMonitor {
 
     private static final Logger LOG = LoggerFactory.getLogger(TaskMonitor.class);
-    private static final TaskMonitor instance = new TaskMonitor();
     private static long EXPIRED_TIME = 172800 * 1000;
 
     private ConcurrentHashMap<Integer, TaskCommunication> tasks = new ConcurrentHashMap<Integer, TaskCommunication>();
 
-    private TaskMonitor() {
-    }
-
-    public static TaskMonitor getInstance() {
-        return instance;
+    public TaskMonitor() {
     }
 
     public void registerTask(Integer taskid, Communication communication) {


### PR DESCRIPTION
TaskMonitor内部维护了一个key为taskid的map存储每个子任务状态用于监控。但是由于TaskMonitor是单例的，当job切分多个TaskGroupContainer时，由于每个TaskGroupContainer内部的taskid都是从0开始累加的，所以会出现不同子任务taskid相同互相覆盖的情况。每个TaskGroupContainer应该拥有一个单独的TaskMonitor实例而不是同一个单例。