### PR TITLE
[bugfix]修复gaussdbreader和gaussdbwriter打包

### DIFF
--- a/gaussdbwriter/src/main/java/com/alibaba/datax/plugin/writer/gaussdbwriter/GaussDbWriter.java
+++ b/gaussdbwriter/src/main/java/com/alibaba/datax/plugin/writer/gaussdbwriter/GaussDbWriter.java
@@ -1,4 +1,4 @@
-package com.alibaba.datax.plugin.reader.gaussdbwriter;
+package com.alibaba.datax.plugin.writer.gaussdbwriter;
 
 import com.alibaba.datax.common.exception.DataXException;
 import com.alibaba.datax.common.plugin.RecordReceiver;

--- a/package.xml
+++ b/package.xml
@@ -257,6 +257,13 @@
             </includes>
             <outputDirectory>datax</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>gaussdbreader/target/datax/</directory>
+            <includes>
+                <include>**/*.*</include>
+            </includes>
+            <outputDirectory>datax</outputDirectory>
+        </fileSet>
 
         <!-- writer -->
         <fileSet>
@@ -541,6 +548,13 @@
         </fileSet>
         <fileSet>
             <directory>sybasewriter/target/datax/</directory>
+            <includes>
+                <include>**/*.*</include>
+            </includes>
+            <outputDirectory>datax</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>gaussdbwriter/target/datax/</directory>
             <includes>
                 <include>**/*.*</include>
             </includes>


### PR DESCRIPTION
gaussdbreader和gaussdbwriter没有在datax-all的package.xml中配置，因此打包后的target中没有这两个插件。

报错如图所示：
```
com.alibaba.datax.common.exception.DataXException: Code:[Framework-12], Description:[DataX插件初始化错误, 该问题通常是由于DataX安装错误引起，请联系您的运维解决 .].  - 插件加载失败，未完成指定插件加载:[gaussdbwriter, gaussdbreader]

	at com.alibaba.datax.common.exception.DataXException.asDataXException(DataXException.java:30)
	at com.alibaba.datax.core.util.ConfigParser.parsePluginConfig(ConfigParser.java:142)
	at com.alibaba.datax.core.util.ConfigParser.parse(ConfigParser.java:63)
	at com.alibaba.datax.core.Engine.entry(Engine.java:131)
	at TaskTest.gaussdb2gaussdb(TaskTest.java:133)
```
	
添加打包配置后：
<img width="416" alt="image" src="https://github.com/user-attachments/assets/f9fc895f-fa29-4b68-aae3-1d3634d8fc5b">
<img width="409" alt="image" src="https://github.com/user-attachments/assets/1feedff9-a0be-408c-bba1-7cb1e52b0407">
