### PR TITLE
fix ftp reader/writer md doc

### DIFF
--- a/ftpreader/doc/ftpreader.md
+++ b/ftpreader/doc/ftpreader.md
@@ -300,7 +300,6 @@ boolean captureRawRecord = true;
 
 | DataX 内部类型| 远程FTP文件 数据类型    |
 | -------- | -----  |
-|
 | Long     |Long |
 | Double   |Double|
 | String   |String|

--- a/ftpwriter/doc/ftpwriter.md
+++ b/ftpwriter/doc/ftpwriter.md
@@ -225,7 +225,6 @@ FTP文件本身不提供数据类型，该类型是DataX FtpWriter定义：
 
 | DataX 内部类型| FTP文件 数据类型    |
 | -------- | -----  |
-| 
 | Long     |Long -> 字符串序列化表示|
 | Double   |Double -> 字符串序列化表示|
 | String   |String -> 字符串序列化表示| 


### PR DESCRIPTION
fix wrong github markdown format in  ftp reader/writer doc

**Before Changes:**
---
![image](https://github.com/user-attachments/assets/1e428760-f2b3-40d3-8692-b1863f6d4880)



**After Changes:**
---
![image](https://github.com/user-attachments/assets/b0a13984-3c66-4ec5-91e2-4b4b76a89bb6)
