### PR TITLE
Bytehouse provide

### DIFF
--- a/bytehousereader/pom.xml
+++ b/bytehousereader/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.datax</groupId>
+        <artifactId>datax-all</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>bytehousereader</artifactId>
+    <name>Archetype - bytehousereader</name>
+    <url>http://maven.apache.org</url>
+</project>

--- a/bytehousereader/pom.xml
+++ b/bytehousereader/pom.xml
@@ -1,12 +1,97 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.alibaba.datax</groupId>
         <artifactId>datax-all</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
     <artifactId>bytehousereader</artifactId>
-    <name>Archetype - bytehousereader</name>
-    <url>http://maven.apache.org</url>
+    <name>bytehousereader</name>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <bytehouse.version>1.1.58</bytehouse.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <!--	Bytehouse  JDBC 驱动 -->
+            <groupId>com.bytedance.bytehouse</groupId>
+            <artifactId>driver-java</artifactId>
+            <version>${bytehouse.version}</version>
+            <classifier>all</classifier>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>datax-core</artifactId>
+            <version>${datax-project-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>datax-common</artifactId>
+            <version>${datax-project-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>plugin-rdbms-util</artifactId>
+            <version>${datax-project-version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- compiler plugin -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${jdk-version}</source>
+                    <target>${jdk-version}</target>
+                    <encoding>${project-sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <!-- assembly plugin -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/package.xml</descriptor>
+                    </descriptors>
+                    <finalName>datax</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>dwzip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/bytehousereader/src/main/assembly/package.xml
+++ b/bytehousereader/src/main/assembly/package.xml
@@ -1,0 +1,35 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id></id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>plugin.json</include>
+                <include>plugin_job_template.json</include>
+            </includes>
+            <outputDirectory>plugin/reader/bytehousereader</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>target/</directory>
+            <includes>
+                <include>bytehousereader-0.0.1-SNAPSHOT.jar</include>
+            </includes>
+            <outputDirectory>plugin/reader/bytehousereader</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>plugin/reader/bytehousereader/libs</outputDirectory>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/bytehousereader/src/main/java/com/alibaba/datax/plugin/reader/bytehousereader/BytehouseReader.java
+++ b/bytehousereader/src/main/java/com/alibaba/datax/plugin/reader/bytehousereader/BytehouseReader.java
@@ -1,0 +1,78 @@
+package com.alibaba.datax.plugin.reader.bytehousereader;
+
+import com.alibaba.datax.common.plugin.RecordSender;
+import com.alibaba.datax.common.spi.Reader;
+import com.alibaba.datax.common.util.Configuration;
+import com.alibaba.datax.plugin.rdbms.reader.CommonRdbmsReader;
+import com.alibaba.datax.plugin.rdbms.reader.Constant;
+import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class BytehouseReader {
+
+
+    private static final DataBaseType DATABASE_TYPE = DataBaseType.ByteHouse;
+    private static final Logger LOG = LoggerFactory.getLogger(BytehouseReader.class);
+
+    public static class Job extends Reader.Job {
+        private Configuration jobConfig = null;
+        private CommonRdbmsReader.Job commonRdbmsReaderMaster;
+        @Override
+        public void init() {
+            this.jobConfig = super.getPluginJobConf();
+            int fetchSize = this.jobConfig.getInt(Constant.FETCH_SIZE, Integer.MIN_VALUE);
+            this.jobConfig.set(Constant.FETCH_SIZE, fetchSize);
+            this.commonRdbmsReaderMaster = new CommonRdbmsReader.Job(DATABASE_TYPE);
+            this.commonRdbmsReaderMaster.init(this.jobConfig);
+        }
+
+        @Override
+        public List<Configuration> split(int mandatoryNumber) {
+            return this.commonRdbmsReaderMaster.split(this.jobConfig, mandatoryNumber);
+        }
+
+        @Override
+        public void post() {
+            this.commonRdbmsReaderMaster.post(this.jobConfig);
+        }
+
+        @Override
+        public void destroy() {
+            this.commonRdbmsReaderMaster.destroy(this.jobConfig);
+        }
+    }
+
+    public static class Task extends Reader.Task {
+
+        private Configuration jobConfig;
+        private CommonRdbmsReader.Task commonRdbmsReaderSlave;
+
+        @Override
+        public void init() {
+            this.jobConfig = super.getPluginJobConf();
+            this.commonRdbmsReaderSlave = new CommonRdbmsReader.Task(DATABASE_TYPE, super.getTaskGroupId(), super.getTaskId());
+            this.commonRdbmsReaderSlave.init(this.jobConfig);
+        }
+
+        @Override
+        public void startRead(RecordSender recordSender) {
+            int fetchSize = this.jobConfig.getInt(com.alibaba.datax.plugin.rdbms.reader.Constant.FETCH_SIZE, 1000);
+
+            this.commonRdbmsReaderSlave.startRead(this.jobConfig, recordSender, super.getTaskPluginCollector(), fetchSize);
+        }
+
+        @Override
+        public void post() {
+            this.commonRdbmsReaderSlave.post(this.jobConfig);
+        }
+
+        @Override
+        public void destroy() {
+            this.commonRdbmsReaderSlave.destroy(this.jobConfig);
+        }
+    }
+
+}

--- a/bytehousereader/src/main/resources/plugin.json
+++ b/bytehousereader/src/main/resources/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "bytehousereader",
+  "class": "com.alibaba.datax.plugin.reader.bytehousereader.BytehouseReader",
+  "description": "useScene: prod. mechanism: Jdbc connection using the database, execute select sql.",
+  "developer": "alibaba"
+}

--- a/bytehousereader/src/main/resources/plugin_job_template.json
+++ b/bytehousereader/src/main/resources/plugin_job_template.json
@@ -1,0 +1,16 @@
+{
+  "name": "bytehousereader",
+  "parameter": {
+    "username": "username",
+    "password": "password",
+    "column": ["col1", "col2", "col3"],
+    "connection": [
+      {
+        "jdbcUrl": "jdbc:bytehouse://<host>:<port>[/<database>]",
+        "table": ["table1", "table2"]
+      }
+    ],
+    "preSql": [],
+    "postSql": []
+  }
+}

--- a/bytehousewriter/pom.xml
+++ b/bytehousewriter/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.datax</groupId>
+        <artifactId>datax-all</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>bytehousewriter</artifactId>
+    <name>Archetype - bytehousewriter</name>
+    <url>http://maven.apache.org</url>
+</project>

--- a/bytehousewriter/pom.xml
+++ b/bytehousewriter/pom.xml
@@ -1,12 +1,96 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.alibaba.datax</groupId>
         <artifactId>datax-all</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
     <artifactId>bytehousewriter</artifactId>
-    <name>Archetype - bytehousewriter</name>
-    <url>http://maven.apache.org</url>
+    <name>bytehousewriter</name>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <bytehouse.version>1.1.58</bytehouse.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <!--	Bytehouse  JDBC 驱动 -->
+            <groupId>com.bytedance.bytehouse</groupId>
+            <artifactId>driver-java</artifactId>
+            <version>${bytehouse.version}</version>
+            <classifier>all</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>datax-core</artifactId>
+            <version>${datax-project-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>datax-common</artifactId>
+            <version>${datax-project-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.datax</groupId>
+            <artifactId>plugin-rdbms-util</artifactId>
+            <version>${datax-project-version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- compiler plugin -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${jdk-version}</source>
+                    <target>${jdk-version}</target>
+                    <encoding>${project-sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <!-- assembly plugin -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/package.xml</descriptor>
+                    </descriptors>
+                    <finalName>datax</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>dwzip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/bytehousewriter/src/main/assembly/package.xml
+++ b/bytehousewriter/src/main/assembly/package.xml
@@ -1,0 +1,35 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id></id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>plugin.json</include>
+ 				<include>plugin_job_template.json</include>
+ 			</includes>
+            <outputDirectory>plugin/writer/bytehousewriter</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>target/</directory>
+            <includes>
+                <include>bytehousewriter-0.0.1-SNAPSHOT.jar</include>
+            </includes>
+            <outputDirectory>plugin/writer/bytehousewriter</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>plugin/writer/bytehousewriter/libs</outputDirectory>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/bytehousewriter/src/main/java/com/alibaba/datax/plugin/writer/bytehousewriter/BytehouseWriter.java
+++ b/bytehousewriter/src/main/java/com/alibaba/datax/plugin/writer/bytehousewriter/BytehouseWriter.java
@@ -128,7 +128,7 @@ public class BytehouseWriter extends Writer {
 										preparedStatement.setInt(columnIndex + 1, column.asBigInteger().intValue());
 									}
 								} else {
-									java.sql.Date sqlDate = null;
+									Date sqlDate = null;
 									try {
 										utilDate = column.asDate();
 									} catch (DataXException e) {
@@ -137,14 +137,14 @@ public class BytehouseWriter extends Writer {
 									}
 
 									if (null != utilDate) {
-										sqlDate = new java.sql.Date(utilDate.getTime());
+										sqlDate = new Date(utilDate.getTime());
 									}
 									preparedStatement.setDate(columnIndex + 1, sqlDate);
 								}
 								break;
 
 							case Types.TIME:
-								java.sql.Time sqlTime = null;
+								Time sqlTime = null;
 								try {
 									utilDate = column.asDate();
 								} catch (DataXException e) {
@@ -153,7 +153,7 @@ public class BytehouseWriter extends Writer {
 								}
 
 								if (null != utilDate) {
-									sqlTime = new java.sql.Time(utilDate.getTime());
+									sqlTime = new Time(utilDate.getTime());
 								}
 								preparedStatement.setTime(columnIndex + 1, sqlTime);
 								break;

--- a/bytehousewriter/src/main/java/com/alibaba/datax/plugin/writer/bytehousewriter/BytehouseWriter.java
+++ b/bytehousewriter/src/main/java/com/alibaba/datax/plugin/writer/bytehousewriter/BytehouseWriter.java
@@ -1,0 +1,324 @@
+package com.alibaba.datax.plugin.writer.bytehousewriter;
+
+import com.alibaba.datax.common.element.Column;
+import com.alibaba.datax.common.element.StringColumn;
+import com.alibaba.datax.common.exception.CommonErrorCode;
+import com.alibaba.datax.common.exception.DataXException;
+import com.alibaba.datax.common.plugin.RecordReceiver;
+import com.alibaba.datax.common.spi.Writer;
+import com.alibaba.datax.common.util.Configuration;
+import com.alibaba.datax.plugin.rdbms.util.DBUtilErrorCode;
+import com.alibaba.datax.plugin.rdbms.util.DataBaseType;
+import com.alibaba.datax.plugin.rdbms.writer.CommonRdbmsWriter;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+
+import java.sql.*;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class BytehouseWriter extends Writer {
+	private static final DataBaseType DATABASE_TYPE = DataBaseType.ByteHouse;
+
+	public static class Job extends Writer.Job {
+		private Configuration originalConfig = null;
+		private CommonRdbmsWriter.Job commonRdbmsWriterMaster;
+
+		@Override
+		public void init() {
+			this.originalConfig = super.getPluginJobConf();
+			this.commonRdbmsWriterMaster = new CommonRdbmsWriter.Job(DATABASE_TYPE);
+			this.commonRdbmsWriterMaster.init(this.originalConfig);
+		}
+
+		@Override
+		public void prepare() {
+			this.commonRdbmsWriterMaster.prepare(this.originalConfig);
+		}
+
+		@Override
+		public List<Configuration> split(int mandatoryNumber) {
+			return this.commonRdbmsWriterMaster.split(this.originalConfig, mandatoryNumber);
+		}
+
+		@Override
+		public void post() {
+			this.commonRdbmsWriterMaster.post(this.originalConfig);
+		}
+
+		@Override
+		public void destroy() {
+			this.commonRdbmsWriterMaster.destroy(this.originalConfig);
+		}
+	}
+
+	public static class Task extends Writer.Task {
+		private Configuration writerSliceConfig;
+
+		private CommonRdbmsWriter.Task commonRdbmsWriterSlave;
+
+		@Override
+		public void init() {
+			this.writerSliceConfig = super.getPluginJobConf();
+
+			this.commonRdbmsWriterSlave = new CommonRdbmsWriter.Task(DATABASE_TYPE) {
+				@Override
+				protected PreparedStatement fillPreparedStatementColumnType(PreparedStatement preparedStatement, int columnIndex, int columnSqltype, String typeName, Column column) throws SQLException {
+					try {
+						if (column.getRawData() == null) {
+							preparedStatement.setNull(columnIndex + 1, columnSqltype);
+							return preparedStatement;
+						}
+
+						java.util.Date utilDate;
+						switch (columnSqltype) {
+							case Types.CHAR:
+							case Types.NCHAR:
+							case Types.CLOB:
+							case Types.NCLOB:
+							case Types.VARCHAR:
+							case Types.LONGVARCHAR:
+							case Types.NVARCHAR:
+							case Types.LONGNVARCHAR:
+								preparedStatement.setString(columnIndex + 1, column
+										.asString());
+								break;
+
+							case Types.TINYINT:
+							case Types.SMALLINT:
+							case Types.INTEGER:
+							case Types.BIGINT:
+							case Types.DECIMAL:
+							case Types.FLOAT:
+							case Types.REAL:
+							case Types.DOUBLE:
+								String strValue = column.asString();
+								if (emptyAsNull && "".equals(strValue)) {
+									preparedStatement.setNull(columnIndex + 1, columnSqltype);
+								} else {
+									switch (columnSqltype) {
+										case Types.TINYINT:
+										case Types.SMALLINT:
+										case Types.INTEGER:
+											preparedStatement.setInt(columnIndex + 1, column.asBigInteger().intValue());
+											break;
+										case Types.BIGINT:
+											preparedStatement.setLong(columnIndex + 1, column.asLong());
+											break;
+										case Types.DECIMAL:
+											preparedStatement.setBigDecimal(columnIndex + 1, column.asBigDecimal());
+											break;
+										case Types.REAL:
+										case Types.FLOAT:
+											preparedStatement.setFloat(columnIndex + 1, column.asDouble().floatValue());
+											break;
+										case Types.DOUBLE:
+											preparedStatement.setDouble(columnIndex + 1, column.asDouble());
+											break;
+									}
+								}
+								break;
+
+							case Types.DATE:
+								if (this.resultSetMetaData.getRight().get(columnIndex)
+										.equalsIgnoreCase("year")) {
+									if (column.asBigInteger() == null) {
+										preparedStatement.setString(columnIndex + 1, null);
+									} else {
+										preparedStatement.setInt(columnIndex + 1, column.asBigInteger().intValue());
+									}
+								} else {
+									java.sql.Date sqlDate = null;
+									try {
+										utilDate = column.asDate();
+									} catch (DataXException e) {
+										throw new SQLException(String.format(
+												"Date 类型转换错误：[%s]", column));
+									}
+
+									if (null != utilDate) {
+										sqlDate = new java.sql.Date(utilDate.getTime());
+									}
+									preparedStatement.setDate(columnIndex + 1, sqlDate);
+								}
+								break;
+
+							case Types.TIME:
+								java.sql.Time sqlTime = null;
+								try {
+									utilDate = column.asDate();
+								} catch (DataXException e) {
+									throw new SQLException(String.format(
+											"Date 类型转换错误：[%s]", column));
+								}
+
+								if (null != utilDate) {
+									sqlTime = new java.sql.Time(utilDate.getTime());
+								}
+								preparedStatement.setTime(columnIndex + 1, sqlTime);
+								break;
+
+							case Types.TIMESTAMP:
+								Timestamp sqlTimestamp = null;
+								if (column instanceof StringColumn && column.asString() != null) {
+									String timeStampStr = column.asString();
+									// JAVA TIMESTAMP 类型入参必须是 "2017-07-12 14:39:00.123566" 格式
+									String pattern = "^\\d+-\\d+-\\d+ \\d+:\\d+:\\d+.\\d+";
+									boolean isMatch = Pattern.matches(pattern, timeStampStr);
+									if (isMatch) {
+										sqlTimestamp = Timestamp.valueOf(timeStampStr);
+										preparedStatement.setTimestamp(columnIndex + 1, sqlTimestamp);
+										break;
+									}
+								}
+								try {
+									utilDate = column.asDate();
+								} catch (DataXException e) {
+									throw new SQLException(String.format(
+											"Date 类型转换错误：[%s]", column));
+								}
+
+								if (null != utilDate) {
+									sqlTimestamp = new Timestamp(
+											utilDate.getTime());
+								}
+								preparedStatement.setTimestamp(columnIndex + 1, sqlTimestamp);
+								break;
+
+							case Types.BINARY:
+							case Types.VARBINARY:
+							case Types.BLOB:
+							case Types.LONGVARBINARY:
+								preparedStatement.setBytes(columnIndex + 1, column
+										.asBytes());
+								break;
+
+							case Types.BOOLEAN:
+								preparedStatement.setInt(columnIndex + 1, column.asBigInteger().intValue());
+								break;
+
+							// warn: bit(1) -> Types.BIT 可使用setBoolean
+							// warn: bit(>1) -> Types.VARBINARY 可使用setBytes
+							case Types.BIT:
+								if (this.dataBaseType == DataBaseType.MySql) {
+									Boolean asBoolean = column.asBoolean();
+									if (asBoolean != null) {
+										preparedStatement.setBoolean(columnIndex + 1, asBoolean);
+									} else {
+										preparedStatement.setNull(columnIndex + 1, Types.BIT);
+									}
+								} else {
+									preparedStatement.setString(columnIndex + 1, column.asString());
+								}
+								break;
+
+							default:
+								boolean isHandled = fillPreparedStatementColumnType4CustomType(preparedStatement,
+										columnIndex, columnSqltype, column);
+								if (isHandled) {
+									break;
+								}
+								throw DataXException
+										.asDataXException(
+												DBUtilErrorCode.UNSUPPORTED_TYPE,
+												String.format(
+														"您的配置文件中的列配置信息有误. 因为DataX 不支持数据库写入这种字段类型. 字段名:[%s], 字段类型:[%d], 字段Java类型:[%s]. 请修改表中该字段的类型或者不同步该字段.",
+														this.resultSetMetaData.getLeft()
+																.get(columnIndex),
+														this.resultSetMetaData.getMiddle()
+																.get(columnIndex),
+														this.resultSetMetaData.getRight()
+																.get(columnIndex)));
+						}
+						return preparedStatement;
+					} catch (DataXException e) {
+						// fix类型转换或者溢出失败时，将具体哪一列打印出来
+						if (e.getErrorCode() == CommonErrorCode.CONVERT_NOT_SUPPORT ||
+								e.getErrorCode() == CommonErrorCode.CONVERT_OVER_FLOW) {
+							throw DataXException
+									.asDataXException(
+											e.getErrorCode(),
+											String.format(
+													"类型转化错误. 字段名:[%s], 字段类型:[%d], 字段Java类型:[%s]. 请修改表中该字段的类型或者不同步该字段.",
+													this.resultSetMetaData.getLeft()
+															.get(columnIndex),
+													this.resultSetMetaData.getMiddle()
+															.get(columnIndex),
+													this.resultSetMetaData.getRight()
+															.get(columnIndex)));
+						} else {
+							throw e;
+						}
+					}
+				}
+
+				private Object toJavaArray(Object val) {
+					if (null == val) {
+						return null;
+					} else if (val instanceof JSONArray) {
+						Object[] valArray = ((JSONArray) val).toArray();
+						for (int i = 0; i < valArray.length; i++) {
+							valArray[i] = this.toJavaArray(valArray[i]);
+						}
+						return valArray;
+					} else {
+						return val;
+					}
+				}
+
+				boolean fillPreparedStatementColumnType4CustomType(PreparedStatement ps,
+				                                                   int columnIndex, int columnSqltype,
+				                                                   Column column) throws SQLException {
+					switch (columnSqltype) {
+						case Types.OTHER:
+							if (this.resultSetMetaData.getRight().get(columnIndex).startsWith("Tuple")) {
+								throw DataXException
+										.asDataXException(BytehouseWriterErrorCode.TUPLE_NOT_SUPPORTED_ERROR, BytehouseWriterErrorCode.TUPLE_NOT_SUPPORTED_ERROR.getDescription());
+							} else {
+								ps.setString(columnIndex + 1, column.asString());
+							}
+							return true;
+
+						case Types.ARRAY:
+							Connection conn = ps.getConnection();
+							List<Object> values = JSON.parseArray(column.asString(), Object.class);
+							for (int i = 0; i < values.size(); i++) {
+								values.set(i, this.toJavaArray(values.get(i)));
+							}
+							Array array = conn.createArrayOf("String", values.toArray());
+							ps.setArray(columnIndex + 1, array);
+							return true;
+
+						default:
+							break;
+					}
+
+					return false;
+				}
+			};
+
+			this.commonRdbmsWriterSlave.init(this.writerSliceConfig);
+		}
+
+		@Override
+		public void prepare() {
+			this.commonRdbmsWriterSlave.prepare(this.writerSliceConfig);
+		}
+
+		@Override
+		public void startWrite(RecordReceiver recordReceiver) {
+			this.commonRdbmsWriterSlave.startWrite(recordReceiver, this.writerSliceConfig, super.getTaskPluginCollector());
+		}
+
+		@Override
+		public void post() {
+			this.commonRdbmsWriterSlave.post(this.writerSliceConfig);
+		}
+
+		@Override
+		public void destroy() {
+			this.commonRdbmsWriterSlave.destroy(this.writerSliceConfig);
+		}
+	}
+
+}

--- a/bytehousewriter/src/main/java/com/alibaba/datax/plugin/writer/bytehousewriter/BytehouseWriterErrorCode.java
+++ b/bytehousewriter/src/main/java/com/alibaba/datax/plugin/writer/bytehousewriter/BytehouseWriterErrorCode.java
@@ -1,0 +1,31 @@
+package com.alibaba.datax.plugin.writer.bytehousewriter;
+
+import com.alibaba.datax.common.spi.ErrorCode;
+
+public enum BytehouseWriterErrorCode implements ErrorCode {
+	TUPLE_NOT_SUPPORTED_ERROR("clickhouseWriter-00", "不支持TUPLE类型导入."),
+	;
+
+	private final String code;
+	private final String description;
+
+	private BytehouseWriterErrorCode(String code, String description) {
+		this.code = code;
+		this.description = description;
+	}
+
+	@Override
+	public String getCode() {
+		return this.code;
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Code:[%s], Description:[%s].", this.code, this.description);
+	}
+}

--- a/bytehousewriter/src/main/resources/plugin.json
+++ b/bytehousewriter/src/main/resources/plugin.json
@@ -1,0 +1,6 @@
+{
+    "name": "bytehousewriter",
+    "class": "com.alibaba.datax.plugin.writer.bytehousewriter.BytehouseWriter",
+    "description": "useScene: prod. mechanism: Jdbc connection using the database, execute insert sql.",
+    "developer": "penggan(1466927252@qq.com)"
+}

--- a/bytehousewriter/src/main/resources/plugin_job_template.json
+++ b/bytehousewriter/src/main/resources/plugin_job_template.json
@@ -1,0 +1,21 @@
+{
+    "name": "clickhousewriter",
+    "parameter": {
+        "username": "username",
+        "password": "password",
+        "column": ["col1", "col2", "col3"],
+        "connection": [
+            {
+                "jdbcUrl": "jdbc:clickhouse://<host>:<port>[/<database>]",
+                "table": ["table1", "table2"]
+            }
+        ],
+        "preSql": [],
+        "postSql": [],
+
+        "batchSize": 65536,
+        "batchByteSize": 134217728,
+        "dryRun": false,
+        "writeMode": "insert"
+    }
+}

--- a/bytehousewriter/src/main/resources/plugin_job_template.json
+++ b/bytehousewriter/src/main/resources/plugin_job_template.json
@@ -6,7 +6,7 @@
         "column": ["col1", "col2", "col3"],
         "connection": [
             {
-                "jdbcUrl": "jdbc:clickhouse://<host>:<port>[/<database>]",
+                "jdbcUrl": "jdbc:bytehouse://<host>:<port>[/<database>]",
                 "table": ["table1", "table2"]
             }
         ],

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,13 @@
 
         <!-- reader -->
         <fileSet>
+            <directory>bytehousereader/target/datax/</directory>
+            <includes>
+                <include>**/*.*</include>
+            </includes>
+            <outputDirectory>datax</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>mysqlreader/target/datax/</directory>
             <includes>
                 <include>**/*.*</include>
@@ -259,6 +266,13 @@
         </fileSet>
 
         <!-- writer -->
+        <fileSet>
+            <directory>bytehousewriter/target/datax/</directory>
+            <includes>
+                <include>**/*.*</include>
+            </includes>
+            <outputDirectory>datax</outputDirectory>
+        </fileSet>
         <fileSet>
             <directory>mysqlwriter/target/datax/</directory>
             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
         <module>gaussdbreader</module>
         <module>gaussdbwriter</module>
         <module>datax-example</module>
+        <module>bytehousewriter</module>
+        <module>bytehousereader</module>
 
     </modules>
 
@@ -247,6 +249,12 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <!--火山引擎bytehouse-->
+            <id>bytedance</id>
+            <name>ByteDance Public Repository</name>
+            <url>https://artifact.bytedance.com/repository/releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
1. 对源代码的改动极小，只是在DataBaseType增加了bytehouse的支持，依旧采用JDBC协议
2.  bytehouse reader和writer的插件基本用的都是源代码中的公共类，没有复杂的自定义部分
3.  新增了ArrayColumn 简单做了string化，不会影响其它插件
4. 模板
```json
{
	"job": {
		"setting": {
			"speed": {
				"channel": 2
			}
		},
		"content": [
			{
				"reader": {
					"name": "clickhousereader",
					"parameter": {
						"username": "gcods",
						"password": "O95L987rhEc5b36zmdV9",
						"where":"sdk_event_date>='2024-01-01' and  sdk_event_date<'2024-01-02'",
						"column": [
							"sdk_event_hour",
							"sdk_event_minute",
							"sdk_event_date",
							"event_ad_code_id"
						],
						"connection": [
							{
								"table": [
									"table_name"
								],
								"jdbcUrl": [
									"jdbc:clickhouse://1p:8123/test"
								]
							}
						]
					}
				}
				,
				"writer": {
					"name": "bytehousewriter",
					"parameter": {
						"username": "bytehouse",
						"password": "aAUvBmMEoo:eeLDmfk9Mt",
						"column": [
								"sdk_event_hour",
								"sdk_event_minute",
								"sdk_event_date",
								"event_ad_code_id"
						],
						"preSql": [
							" "
						],
						"connection": [
							{
								"jdbcUrl": "jdbc:bytehouse://ip:19000?secure=true&database=test",
								"table": [
									"table_name"
								]
							}
						]
					}
				}
			}
		]
	}
}
```