### PR TITLE
fix: issue #2251 Memory Overflow During Data Insertion with DorisWriter, Task Stuck in Blocked State

### DIFF
--- a/doriswriter/src/main/java/com/alibaba/datax/plugin/writer/doriswriter/DorisWriterManager.java
+++ b/doriswriter/src/main/java/com/alibaba/datax/plugin/writer/doriswriter/DorisWriterManager.java
@@ -26,7 +26,7 @@ public class DorisWriterManager {
     private int batchCount = 0;
     private long batchSize = 0;
     private volatile boolean closed = false;
-    private volatile Exception flushException;
+    private volatile Throwable flushException;
     private final LinkedBlockingDeque< WriterTuple > flushQueue;
     private ScheduledExecutorService scheduler;
     private ScheduledFuture<?> scheduledFuture;
@@ -52,7 +52,7 @@ public class DorisWriterManager {
                             startScheduler();
                         }
                         flush(label, false);
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         flushException = e;
                     }
                 }
@@ -132,7 +132,8 @@ public class DorisWriterManager {
                 while(true) {
                     try {
                         asyncFlush();
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
+                        // catch all exception (include ERROR level) and put into flushException
                         flushException = e;
                     }
                 }


### PR DESCRIPTION
### resolve sync block on memory overflow in Doris
- 当检测到内存溢出时，改进了进程的终止行为，避免了同步操作的长时间阻塞。
- 修复了在内存溢出情况下，Doris 数据同步进程出现阻塞的问题。
- startAsyncFlushing()为异步线程消费flushQueue的数据，如出现内存溢出catch为Exception时则不能捕获到，flushException为null，checkFlushException()则不能检测到异常；异步线程内存溢出主动退出，由于flushQueue数据不能被消费，则导致写入的主线程仍阻塞在flushQueue.put() 
Closes #2251 