### PR TITLE
[Fix][RDBMS] Fix JDBC driver selection for data source connections

### DIFF
--- a/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/util/DBUtil.java
+++ b/plugin-rdbms-util/src/main/java/com/alibaba/datax/plugin/rdbms/util/DBUtil.java
@@ -391,6 +391,21 @@ public final class DBUtil {
                                                    String url, Properties prop) {
         try {
             Class.forName(dataBaseType.getDriverClassName());
+            try {
+                Enumeration<Driver> drivers = DriverManager.getDrivers();
+                while (drivers.hasMoreElements()) {
+                    Driver driver = drivers.nextElement();
+                    if (StringUtils.equals(driver.getClass().getName(), dataBaseType.getDriverClassName())) {
+                        try {
+                            return driver.connect(url, prop);
+                        } catch (Exception e) {
+                            LOG.info("try connector failed", e);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LOG.info("find driver error, back to DriverManager.getConnection", e);
+            }
             DriverManager.setLoginTimeout(Constant.TIMEOUT_SECONDS);
             return DriverManager.getConnection(url, prop);
         } catch (Exception e) {


### PR DESCRIPTION
### Purpose of this pull request

This pull request fixes an issue with JDBC driver selection when dealing with heterogeneous data sources. In the current implementation, DriverManager may select the wrong driver when multiple compatible drivers are available in the classpath. This can cause problems when transferring data between similar databases (like Greenplum to PostgreSQL or MySQL 5 to MySQL 8), where driver "drift" can occur.

The underlying issue exists in the DriverManager's getConnection method implementation: it iterates through all registered drivers and uses the first one that successfully connects to the given URL. As shown in the Java source code, it doesn't prioritize drivers by class name but simply tries each registered driver in sequence:

```java
for(DriverInfo aDriver : registeredDrivers) {
    if(isDriverAllowed(aDriver.driver, callerCL)) {
        try {
            Connection con = aDriver.driver.connect(url, info);
            if (con != null) {
                // Success!
                return (con);
            }
        } catch (SQLException ex) {
            if (reason == null) {
                reason = ex;
            }
        }
    }
}
```

This behavior means that if multiple drivers can handle the same URL format (e.g., both MySQL 5 and MySQL 8 drivers can handle "jdbc:mysql://..." URLs), the one loaded first will be used, regardless of which one is more appropriate for the specific database version being connected to.