### PR TITLE
[FIX]:direct path date type processing

### DIFF
--- a/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/task/DirectPathInsertTask.java
+++ b/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/task/DirectPathInsertTask.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 
+import com.alibaba.datax.common.element.Column;
+import com.alibaba.datax.common.element.Column.Type;
 import com.alibaba.datax.common.element.Record;
 import com.alibaba.datax.common.util.Configuration;
 import com.alibaba.datax.plugin.writer.oceanbasev10writer.common.Table;
@@ -44,7 +46,13 @@ public class DirectPathInsertTask extends AbstractInsertTask {
                 Object[] values = new Object[columnNumber];
                 for (Record record : records) {
                     for (int i = 0; i < columnNumber; i++) {
-                        values[i] = record.getColumn(i).getRawData();
+                        Column column = record.getColumn(i);
+                        //处理一下时间类型
+                        if (column.getType().equals(Type.DATE)) {
+                            values[i] = record.getColumn(i).asString();
+                        } else {
+                            values[i] = record.getColumn(i).getRawData();
+                        }
                     }
                     stmt.addBatch(values);
                 }


### PR DESCRIPTION
[desc]
The time obtained by using the getRowData() method in bypass import is a timestamp of the Long type, which will cause the insertion error during bypass import. If you use asString() directly to convert to string time, it can be inserted correctly. asString() leads to inefficiencies in the case of large text fields. The time type should be treated separately for the other types.
close #2285 
