### PR TITLE
[FIX]:The database of the jdbcUrl connection string of oceanbase should support special characters

### DIFF
--- a/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/ext/ServerConnectInfo.java
+++ b/oceanbasev10writer/src/main/java/com/alibaba/datax/plugin/writer/oceanbasev10writer/ext/ServerConnectInfo.java
@@ -32,7 +32,7 @@ public class ServerConnectInfo {
     }
 
     private void parseJdbcUrl(final String jdbcUrl) {
-        Pattern pattern = Pattern.compile("//([\\w\\.\\-]+:\\d+)/([\\w]+)\\?");
+        Pattern pattern = Pattern.compile("//([\\w\\.\\-]+:\\d+)/([^\\\\?]*)");
         Matcher matcher = pattern.matcher(jdbcUrl);
         if (matcher.find()) {
             String ipPort = matcher.group(1);


### PR DESCRIPTION
[DESC]
com.alibaba.datax.plugin.writer.oceanbasev10writer.ext.ServerConnectInfo#parseJdbcUrl
Pattern pattern = Pattern.compile("//([\\w\\.\\-]+:\\d+)/([^\\\\?]*)");
This regular match cannot be supported when the database name contains special characters
close #2291 