### PR TITLE
[FIX]:solve the problem of increasing or losing data in incremental situations

### DIFF
--- a/oceanbasev10reader/src/main/java/com/alibaba/datax/plugin/reader/oceanbasev10reader/util/ObReaderUtils.java
+++ b/oceanbasev10reader/src/main/java/com/alibaba/datax/plugin/reader/oceanbasev10reader/util/ObReaderUtils.java
@@ -269,7 +269,6 @@ public class ObReaderUtils {
         String[] pkColumns = context.getPkColumns();
         StringBuilder whereClause = new StringBuilder();
 
-        // 无论 MySQL 还是 Oracle 都统一使用 OR 条件链
         if (pkColumns != null && pkColumns.length > 0) {
             whereClause.append(" (");
             for (int i = 0; i < pkColumns.length; i++) {

--- a/oceanbasev10reader/src/main/java/com/alibaba/datax/plugin/reader/oceanbasev10reader/util/ObReaderUtils.java
+++ b/oceanbasev10reader/src/main/java/com/alibaba/datax/plugin/reader/oceanbasev10reader/util/ObReaderUtils.java
@@ -1,6 +1,7 @@
 package com.alibaba.datax.plugin.reader.oceanbasev10reader.util;
 
 import com.alibaba.datax.common.element.*;
+import com.alibaba.datax.common.element.Record;
 import com.alibaba.datax.plugin.rdbms.reader.util.ObVersion;
 import com.alibaba.datax.plugin.rdbms.reader.util.SingleTableSplitUtil;
 import com.alibaba.datax.plugin.rdbms.util.DBUtil;
@@ -10,6 +11,7 @@ import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -26,7 +28,13 @@ import java.util.regex.Pattern;
  */
 public class ObReaderUtils {
     private static final Logger LOG = LoggerFactory.getLogger(ObReaderUtils.class);
-    private static final String MYSQL_KEYWORDS = "ACCESSIBLE,ACCOUNT,ACTION,ADD,AFTER,AGAINST,AGGREGATE,ALGORITHM,ALL,ALTER,ALWAYS,ANALYSE,AND,ANY,AS,ASC,ASCII,ASENSITIVE,AT,AUTO_INCREMENT,AUTOEXTEND_SIZE,AVG,AVG_ROW_LENGTH,BACKUP,BEFORE,BEGIN,BETWEEN,BIGINT,BINARY,BINLOG,BIT,BLOB,BLOCK,BOOL,BOOLEAN,BOTH,BTREE,BY,BYTE,CACHE,CALL,CASCADE,CASCADED,CASE,CATALOG_NAME,CHAIN,CHANGE,CHANGED,CHANNEL,CHAR,CHARACTER,CHARSET,CHECK,CHECKSUM,CIPHER,CLASS_ORIGIN,CLIENT,CLOSE,COALESCE,CODE,COLLATE,COLLATION,COLUMN,COLUMN_FORMAT,COLUMN_NAME,COLUMNS,COMMENT,COMMIT,COMMITTED,COMPACT,COMPLETION,COMPRESSED,COMPRESSION,CONCURRENT,CONDITION,CONNECTION,CONSISTENT,CONSTRAINT,CONSTRAINT_CATALOG,CONSTRAINT_NAME,CONSTRAINT_SCHEMA,CONTAINS,CONTEXT,CONTINUE,CONVERT,CPU,CREATE,CROSS,CUBE,CURRENT,CURRENT_DATE,CURRENT_TIME,CURRENT_TIMESTAMP,CURRENT_USER,CURSOR,CURSOR_NAME,DATA,DATABASE,DATABASES,DATAFILE,DATE,DATETIME,DAY,DAY_HOUR,DAY_MICROSECOND,DAY_MINUTE,DAY_SECOND,DEALLOCATE,DEC,DECIMAL,DECLARE,DEFAULT,DEFAULT_AUTH,DEFINER,DELAY_KEY_WRITE,DELAYED,DELETE,DES_KEY_FILE,DESC,DESCRIBE,DETERMINISTIC,DIAGNOSTICS,DIRECTORY,DISABLE,DISCARD,DISK,DISTINCT,DISTINCTROW,DIV,DO,DOUBLE,DROP,DUAL,DUMPFILE,DUPLICATE,DYNAMIC,EACH,ELSE,ELSEIF,ENABLE,ENCLOSED,ENCRYPTION,END,ENDS,ENGINE,ENGINES,ENUM,ERROR,ERRORS,ESCAPE,ESCAPED,EVENT,EVENTS,EVERY,EXCHANGE,EXECUTE,EXISTS,EXIT,EXPANSION,EXPIRE,EXPLAIN,EXPORT,EXTENDED,EXTENT_SIZE,FAST,FAULTS,FETCH,FIELDS,FILE,FILE_BLOCK_SIZE,FILTER,FIRST,FIXED,FLOAT,FLOAT4,FLOAT8,FLUSH,FOLLOWS,FOR,FORCE,FOREIGN,FORMAT,FOUND,FROM,FULL,FULLTEXT,FUNCTION,GENERAL,GENERATED,GEOMETRY,GEOMETRYCOLLECTION,GET,GET_FORMAT,GLOBAL,GRANT,GRANTS,GROUP,GROUP_REPLICATION,HANDLER,HASH,HAVING,HELP,HIGH_PRIORITY,HOST,HOSTS,HOUR,HOUR_MICROSECOND,HOUR_MINUTE,HOUR_SECOND,IDENTIFIED,IF,IGNORE,IGNORE_SERVER_IDS,IMPORT,IN,INDEX,INDEXES,INFILE,INITIAL_SIZE,INNER,INOUT,INSENSITIVE,INSERT,INSERT_METHOD,INSTALL,INSTANCE,INT,INT1,INT2,INT3,INT4,INT8,INTEGER,INTERVAL,INTO,INVOKER,IO,IO_AFTER_GTIDS,IO_BEFORE_GTIDS,IO_THREAD,IPC,IS,ISOLATION,ISSUER,ITERATE,JOIN,JSON,KEY,KEY_BLOCK_SIZE,KEYS,KILL,LANGUAGE,LAST,LEADING,LEAVE,LEAVES,LEFT,LESS,LEVEL,LIKE,LIMIT,LINEAR,LINES,LINESTRING,LIST,LOAD,LOCAL,LOCALTIME,LOCALTIMESTAMP,LOCK,LOCKS,LOGFILE,LOGS,LONG,LONGBLOB,LONGTEXT,LOOP,LOW_PRIORITY,MASTER,MASTER_AUTO_POSITION,MASTER_BIND,MASTER_CONNECT_RETRY,MASTER_DELAY,MASTER_HEARTBEAT_PERIOD,MASTER_HOST,MASTER_LOG_FILE,MASTER_LOG_POS,MASTER_PASSWORD,MASTER_PORT,MASTER_RETRY_COUNT,MASTER_SERVER_ID,MASTER_SSL,MASTER_SSL_CA,MASTER_SSL_CAPATH,MASTER_SSL_CERT,MASTER_SSL_CIPHER,MASTER_SSL_CRL,MASTER_SSL_CRLPATH,MASTER_SSL_KEY,MASTER_SSL_VERIFY_SERVER_CERT,MASTER_TLS_VERSION,MASTER_USER,MATCH,MAX_CONNECTIONS_PER_HOUR,MAX_QUERIES_PER_HOUR,MAX_ROWS,MAX_SIZE,MAX_STATEMENT_TIME,MAX_UPDATES_PER_HOUR,MAX_USER_CONNECTIONS,MAXVALUE,MEDIUM,MEDIUMBLOB,MEDIUMINT,MEDIUMTEXT,MEMORY,MERGE,MESSAGE_TEXT,MICROSECOND,MIDDLEINT,MIGRATE,MIN_ROWS,MINUTE,MINUTE_MICROSECOND,MINUTE_SECOND,MOD,MODE,MODIFIES,MODIFY,MONTH,MULTILINESTRING,MULTIPOINT,MULTIPOLYGON,MUTEX,MYSQL_ERRNO,NAME,NAMES,NATIONAL,NATURAL,NCHAR,NDB,NDBCLUSTER,NEVER,NEW,NEXT,NO,NO_WAIT,NO_WRITE_TO_BINLOG,NODEGROUP,NONBLOCKING,NONE,NOT,NULL,NUMBER,NUMERIC,NVARCHAR,OFFSET,OLD_PASSWORD,ON,ONE,ONLY,OPEN,OPTIMIZE,OPTIMIZER_COSTS,OPTION,OPTIONALLY,OPTIONS,OR,ORDER,OUT,OUTER,OUTFILE,OWNER,PACK_KEYS,PAGE,PARSE_GCOL_EXPR,PARSER,PARTIAL,PARTITION,PARTITIONING,PARTITIONS,PASSWORD,PHASE,PLUGIN,PLUGIN_DIR,PLUGINS,POINT,POLYGON,PORT,PRECEDES,PRECISION,PREPARE,PRESERVE,PREV,PRIMARY,PRIVILEGES,PROCEDURE,PROCESSLIST,PROFILE,PROFILES,PROXY,PURGE,QUARTER,QUERY,QUICK,RANGE,READ,READ_ONLY,READ_WRITE,READS,REAL,REBUILD,RECOVER,REDO_BUFFER_SIZE,REDOFILE,REDUNDANT,REFERENCES,REGEXP,RELAY,RELAY_LOG_FILE,RELAY_LOG_POS,RELAY_THREAD,RELAYLOG,RELEASE,RELOAD,REMOVE,RENAME,REORGANIZE,REPAIR,REPEAT,REPEATABLE,REPLACE,REPLICATE_DO_DB,REPLICATE_DO_TABLE,REPLICATE_IGNORE_DB,REPLICATE_IGNORE_TABLE,REPLICATE_REWRITE_DB,REPLICATE_WILD_DO_TABLE,REPLICATE_WILD_IGNORE_TABLE,REPLICATION,REQUIRE,RESET,RESIGNAL,RESTORE,RESTRICT,RESUME,RETURN,RETURNED_SQLSTATE,RETURNS,REVERSE,REVOKE,RIGHT,RLIKE,ROLLBACK,ROLLUP,ROTATE,ROUTINE,ROW,ROW_COUNT,ROW_FORMAT,ROWS,RTREE,SAVEPOINT,SCHEDULE,SCHEMA,SCHEMA_NAME,SCHEMAS,SECOND,SECOND_MICROSECOND,SECURITY,SELECT,SENSITIVE,SEPARATOR,SERIAL,SERIALIZABLE,SERVER,SESSION,SET,SHARE,SHOW,SHUTDOWN,SIGNAL,SIGNED,SIMPLE,SLAVE,SLOW,SMALLINT,SNAPSHOT,SOCKET,SOME,SONAME,SOUNDS,SOURCE,SPATIAL,SPECIFIC,SQL,SQL_AFTER_GTIDS,SQL_AFTER_MTS_GAPS,SQL_BEFORE_GTIDS,SQL_BIG_RESULT,SQL_BUFFER_RESULT,SQL_CACHE,SQL_CALC_FOUND_ROWS,SQL_NO_CACHE,SQL_SMALL_RESULT,SQL_THREAD,SQL_TSI_DAY,SQL_TSI_HOUR,SQL_TSI_MINUTE,SQL_TSI_MONTH,SQL_TSI_QUARTER,SQL_TSI_SECOND,SQL_TSI_WEEK,SQL_TSI_YEAR,SQLEXCEPTION,SQLSTATE,SQLWARNING,SSL,STACKED,START,STARTING,STARTS,STATS_AUTO_RECALC,STATS_PERSISTENT,STATS_SAMPLE_PAGES,STATUS,STOP,STORAGE,STORED,STRAIGHT_JOIN,STRING,SUBCLASS_ORIGIN,SUBJECT,SUBPARTITION,SUBPARTITIONS,SUPER,SUSPEND,SWAPS,SWITCHES,TABLE,TABLE_CHECKSUM,TABLE_NAME,TABLES,TABLESPACE,TEMPORARY,TEMPTABLE,TERMINATED,TEXT,THAN,THEN,TIME,TIMESTAMP,TIMESTAMPADD,TIMESTAMPDIFF,TINYBLOB,TINYINT,TINYTEXT,TO,TRAILING,TRANSACTION,TRIGGER,TRIGGERS,TRUNCATE,TYPE,TYPES,UNCOMMITTED,UNDEFINED,UNDO,UNDO_BUFFER_SIZE,UNDOFILE,UNICODE,UNINSTALL,UNION,UNIQUE,UNKNOWN,UNLOCK,UNSIGNED,UNTIL,UPDATE,UPGRADE,USAGE,USE,USE_FRM,USER,USER_RESOURCES,USING,UTC_DATE,UTC_TIME,UTC_TIMESTAMP,VALIDATION,VALUE,VALUES,VARBINARY,VARCHAR,VARCHARACTER,VARIABLES,VARYING,VIEW,VIRTUAL,WAIT,WARNINGS,WEEK,WEIGHT_STRING,WHEN,WHERE,WHILE,WITH,WITHOUT,WORK,WRAPPER,WRITE,X509,XA,XID,XML,XOR,YEAR,YEAR_MONTH,ZEROFILL,FALSE,TRUE";
+    private static final String MYSQL_KEYWORDS
+            = "ACCESSIBLE,ACCOUNT,ACTION,ADD,AFTER,AGAINST,AGGREGATE,ALGORITHM,ALL,ALTER,ALWAYS,ANALYSE,AND,ANY,AS,ASC,ASCII,ASENSITIVE,AT,AUTO_INCREMENT,AUTOEXTEND_SIZE,AVG,AVG_ROW_LENGTH,BACKUP,BEFORE,BEGIN,BETWEEN,BIGINT,BINARY,BINLOG,BIT,BLOB,BLOCK,BOOL,BOOLEAN,BOTH,BTREE,BY,BYTE,CACHE,CALL,CASCADE,CASCADED,CASE,CATALOG_NAME,CHAIN,CHANGE,CHANGED,CHANNEL,CHAR,CHARACTER,CHARSET,CHECK,CHECKSUM,CIPHER,CLASS_ORIGIN,CLIENT,CLOSE,COALESCE,CODE,COLLATE,COLLATION,COLUMN,COLUMN_FORMAT,COLUMN_NAME,COLUMNS,COMMENT,COMMIT,COMMITTED,COMPACT,COMPLETION,COMPRESSED,COMPRESSION,CONCURRENT,CONDITION,CONNECTION,CONSISTENT,CONSTRAINT,CONSTRAINT_CATALOG,CONSTRAINT_NAME,CONSTRAINT_SCHEMA,CONTAINS,CONTEXT,CONTINUE,CONVERT,CPU,CREATE,CROSS,CUBE,CURRENT,CURRENT_DATE,CURRENT_TIME,CURRENT_TIMESTAMP,CURRENT_USER,CURSOR,CURSOR_NAME,DATA,DATABASE,DATABASES,DATAFILE,DATE,DATETIME,DAY,DAY_HOUR,DAY_MICROSECOND,DAY_MINUTE,DAY_SECOND,DEALLOCATE,DEC,DECIMAL,DECLARE,DEFAULT,DEFAULT_AUTH,DEFINER,DELAY_KEY_WRITE,"
+            + "DELAYED,DELETE,DES_KEY_FILE,DESC,DESCRIBE,DETERMINISTIC,DIAGNOSTICS,DIRECTORY,DISABLE,DISCARD,DISK,DISTINCT,DISTINCTROW,DIV,DO,DOUBLE,DROP,DUAL,DUMPFILE,DUPLICATE,DYNAMIC,EACH,ELSE,ELSEIF,ENABLE,ENCLOSED,ENCRYPTION,END,ENDS,ENGINE,ENGINES,ENUM,ERROR,ERRORS,ESCAPE,ESCAPED,EVENT,EVENTS,EVERY,EXCHANGE,EXECUTE,EXISTS,EXIT,EXPANSION,EXPIRE,EXPLAIN,EXPORT,EXTENDED,EXTENT_SIZE,FAST,FAULTS,FETCH,FIELDS,FILE,FILE_BLOCK_SIZE,FILTER,FIRST,FIXED,FLOAT,FLOAT4,FLOAT8,FLUSH,FOLLOWS,FOR,FORCE,FOREIGN,FORMAT,FOUND,FROM,FULL,FULLTEXT,FUNCTION,GENERAL,GENERATED,GEOMETRY,GEOMETRYCOLLECTION,GET,GET_FORMAT,GLOBAL,GRANT,GRANTS,GROUP,GROUP_REPLICATION,HANDLER,HASH,HAVING,HELP,HIGH_PRIORITY,HOST,HOSTS,HOUR,HOUR_MICROSECOND,HOUR_MINUTE,HOUR_SECOND,IDENTIFIED,IF,IGNORE,IGNORE_SERVER_IDS,IMPORT,IN,INDEX,INDEXES,INFILE,INITIAL_SIZE,INNER,INOUT,INSENSITIVE,INSERT,INSERT_METHOD,INSTALL,INSTANCE,INT,INT1,INT2,INT3,INT4,INT8,INTEGER,INTERVAL,INTO,INVOKER,IO,IO_AFTER_GTIDS,IO_BEFORE_GTIDS,IO_THREAD,"
+            + "IPC,IS,ISOLATION,ISSUER,ITERATE,JOIN,JSON,KEY,KEY_BLOCK_SIZE,KEYS,KILL,LANGUAGE,LAST,LEADING,LEAVE,LEAVES,LEFT,LESS,LEVEL,LIKE,LIMIT,LINEAR,LINES,LINESTRING,LIST,LOAD,LOCAL,LOCALTIME,LOCALTIMESTAMP,LOCK,LOCKS,LOGFILE,LOGS,LONG,LONGBLOB,LONGTEXT,LOOP,LOW_PRIORITY,MASTER,MASTER_AUTO_POSITION,MASTER_BIND,MASTER_CONNECT_RETRY,MASTER_DELAY,MASTER_HEARTBEAT_PERIOD,MASTER_HOST,MASTER_LOG_FILE,MASTER_LOG_POS,MASTER_PASSWORD,MASTER_PORT,MASTER_RETRY_COUNT,MASTER_SERVER_ID,MASTER_SSL,MASTER_SSL_CA,MASTER_SSL_CAPATH,MASTER_SSL_CERT,MASTER_SSL_CIPHER,MASTER_SSL_CRL,MASTER_SSL_CRLPATH,MASTER_SSL_KEY,MASTER_SSL_VERIFY_SERVER_CERT,MASTER_TLS_VERSION,MASTER_USER,MATCH,MAX_CONNECTIONS_PER_HOUR,MAX_QUERIES_PER_HOUR,MAX_ROWS,MAX_SIZE,MAX_STATEMENT_TIME,MAX_UPDATES_PER_HOUR,MAX_USER_CONNECTIONS,MAXVALUE,MEDIUM,MEDIUMBLOB,MEDIUMINT,MEDIUMTEXT,MEMORY,MERGE,MESSAGE_TEXT,MICROSECOND,MIDDLEINT,MIGRATE,MIN_ROWS,MINUTE,MINUTE_MICROSECOND,MINUTE_SECOND,MOD,MODE,MODIFIES,MODIFY,MONTH,"
+            + "MULTILINESTRING,MULTIPOINT,MULTIPOLYGON,MUTEX,MYSQL_ERRNO,NAME,NAMES,NATIONAL,NATURAL,NCHAR,NDB,NDBCLUSTER,NEVER,NEW,NEXT,NO,NO_WAIT,NO_WRITE_TO_BINLOG,NODEGROUP,NONBLOCKING,NONE,NOT,NULL,NUMBER,NUMERIC,NVARCHAR,OFFSET,OLD_PASSWORD,ON,ONE,ONLY,OPEN,OPTIMIZE,OPTIMIZER_COSTS,OPTION,OPTIONALLY,OPTIONS,OR,ORDER,OUT,OUTER,OUTFILE,OWNER,PACK_KEYS,PAGE,PARSE_GCOL_EXPR,PARSER,PARTIAL,PARTITION,PARTITIONING,PARTITIONS,PASSWORD,PHASE,PLUGIN,PLUGIN_DIR,PLUGINS,POINT,POLYGON,PORT,PRECEDES,PRECISION,PREPARE,PRESERVE,PREV,PRIMARY,PRIVILEGES,PROCEDURE,PROCESSLIST,PROFILE,PROFILES,PROXY,PURGE,QUARTER,QUERY,QUICK,RANGE,READ,READ_ONLY,READ_WRITE,READS,REAL,REBUILD,RECOVER,REDO_BUFFER_SIZE,REDOFILE,REDUNDANT,REFERENCES,REGEXP,RELAY,RELAY_LOG_FILE,RELAY_LOG_POS,RELAY_THREAD,RELAYLOG,RELEASE,RELOAD,REMOVE,RENAME,REORGANIZE,REPAIR,REPEAT,REPEATABLE,REPLACE,REPLICATE_DO_DB,REPLICATE_DO_TABLE,REPLICATE_IGNORE_DB,REPLICATE_IGNORE_TABLE,REPLICATE_REWRITE_DB,REPLICATE_WILD_DO_TABLE,"
+            + "REPLICATE_WILD_IGNORE_TABLE,REPLICATION,REQUIRE,RESET,RESIGNAL,RESTORE,RESTRICT,RESUME,RETURN,RETURNED_SQLSTATE,RETURNS,REVERSE,REVOKE,RIGHT,RLIKE,ROLLBACK,ROLLUP,ROTATE,ROUTINE,ROW,ROW_COUNT,ROW_FORMAT,ROWS,RTREE,SAVEPOINT,SCHEDULE,SCHEMA,SCHEMA_NAME,SCHEMAS,SECOND,SECOND_MICROSECOND,SECURITY,SELECT,SENSITIVE,SEPARATOR,SERIAL,SERIALIZABLE,SERVER,SESSION,SET,SHARE,SHOW,SHUTDOWN,SIGNAL,SIGNED,SIMPLE,SLAVE,SLOW,SMALLINT,SNAPSHOT,SOCKET,SOME,SONAME,SOUNDS,SOURCE,SPATIAL,SPECIFIC,SQL,SQL_AFTER_GTIDS,SQL_AFTER_MTS_GAPS,SQL_BEFORE_GTIDS,SQL_BIG_RESULT,SQL_BUFFER_RESULT,SQL_CACHE,SQL_CALC_FOUND_ROWS,SQL_NO_CACHE,SQL_SMALL_RESULT,SQL_THREAD,SQL_TSI_DAY,SQL_TSI_HOUR,SQL_TSI_MINUTE,SQL_TSI_MONTH,SQL_TSI_QUARTER,SQL_TSI_SECOND,SQL_TSI_WEEK,SQL_TSI_YEAR,SQLEXCEPTION,SQLSTATE,SQLWARNING,SSL,STACKED,START,STARTING,STARTS,STATS_AUTO_RECALC,STATS_PERSISTENT,STATS_SAMPLE_PAGES,STATUS,STOP,STORAGE,STORED,STRAIGHT_JOIN,STRING,SUBCLASS_ORIGIN,SUBJECT,SUBPARTITION,SUBPARTITIONS,SUPER,"
+            + "SUSPEND,SWAPS,SWITCHES,TABLE,TABLE_CHECKSUM,TABLE_NAME,TABLES,TABLESPACE,TEMPORARY,TEMPTABLE,TERMINATED,TEXT,THAN,THEN,TIME,TIMESTAMP,TIMESTAMPADD,TIMESTAMPDIFF,TINYBLOB,TINYINT,TINYTEXT,TO,TRAILING,TRANSACTION,TRIGGER,TRIGGERS,TRUNCATE,TYPE,TYPES,UNCOMMITTED,UNDEFINED,UNDO,UNDO_BUFFER_SIZE,UNDOFILE,UNICODE,UNINSTALL,UNION,UNIQUE,UNKNOWN,UNLOCK,UNSIGNED,UNTIL,UPDATE,UPGRADE,USAGE,USE,USE_FRM,USER,USER_RESOURCES,USING,UTC_DATE,UTC_TIME,UTC_TIMESTAMP,VALIDATION,VALUE,VALUES,VARBINARY,VARCHAR,VARCHARACTER,VARIABLES,VARYING,VIEW,VIRTUAL,WAIT,WARNINGS,WEEK,WEIGHT_STRING,WHEN,WHERE,WHILE,WITH,WITHOUT,WORK,WRAPPER,WRITE,X509,XA,XID,XML,XOR,YEAR,YEAR_MONTH,ZEROFILL,FALSE,TRUE";
     private static final String ORACLE_KEYWORDS = "ACCESS,ADD,ALL,ALTER,AND,ANY,ARRAYLEN,AS,ASC,AUDIT,BETWEEN,BY,CHAR,CHECK,CLUSTER,COLUMN,COMMENT,COMPRESS,CONNECT,CREATE,CURRENT,DATE,DECIMAL,DEFAULT,DELETE,DESC,DISTINCT,DROP,ELSE,EXCLUSIVE,EXISTS,FILE,FLOAT,FOR,FROM,GRANT,GROUP,HAVING,IDENTIFIED,IMMEDIATE,IN,INCREMENT,INDEX,INITIAL,INSERT,INTEGER,INTERSECT,INTO,IS,LEVEL,LIKE,LOCK,LONG,MAXEXTENTS,MINUS,MODE,MODIFY,NOAUDIT,NOCOMPRESS,NOT,NOTFOUND,NOWAIT,NUMBER,OF,OFFLINE,ON,ONLINE,OPTION,OR,ORDER,PCTFREE,PRIOR,PRIVILEGES,PUBLIC,RAW,RENAME,RESOURCE,REVOKE,ROW,ROWID,ROWLABEL,ROWNUM,ROWS,SELECT,SESSION,SET,SHARE,SIZE,SMALLINT,SQLBUF,START,SUCCESSFUL,SYNONYM,TABLE,THEN,TO,TRIGGER,UID,UNION,UNIQUE,UPDATE,USER,VALIDATE,VALUES,VARCHAR,VARCHAR2,VIEW,WHENEVER,WHERE,WITH,KEY,NAME,VALUE,TYPE";
 
     private static Set<String> databaseKeywords;
@@ -127,7 +135,7 @@ public class ObReaderUtils {
                 // 如果用户定义的 columns中 带有 ``,也不影响,
                 // 最多只是在select里多加了几列PK column
                 if (StringUtils.equalsIgnoreCase(pkc, columns.get(j))
-                    || StringUtils.equalsIgnoreCase(escapedPkc, columns.get(j))) {
+                        || StringUtils.equalsIgnoreCase(escapedPkc, columns.get(j))) {
                     pkIndexs[i] = j;
                     pkColumns[i] = columns.get(j);
                     break;
@@ -156,13 +164,13 @@ public class ObReaderUtils {
             }
             //OceanBase oracle模式下需要使用position排序获取正确的联合主键顺序
             sql = String.format(
-                "SELECT cols.column_name Column_name " +
-                    "FROM all_constraints cons, all_cons_columns cols " +
-                    "WHERE cols.table_name = '%s' AND cons.constraint_type = 'P' " +
-                    "AND cons.constraint_name = cols.constraint_name " +
-                    "AND cons.owner = cols.owner and cons.OWNER = %s " +
-                    "order by cols.position " ,
-                tableName, schema);
+                    "SELECT cols.column_name Column_name " +
+                            "FROM all_constraints cons, all_cons_columns cols " +
+                            "WHERE cols.table_name = '%s' AND cons.constraint_type = 'P' " +
+                            "AND cons.constraint_name = cols.constraint_name " +
+                            "AND cons.owner = cols.owner and cons.OWNER = %s " +
+                            "order by cols.position ",
+                    tableName, schema);
         }
         LOG.info("get primary key by sql: " + sql);
         Statement ps = null;
@@ -227,11 +235,9 @@ public class ObReaderUtils {
             sql += (StringUtils.isNotEmpty(context.getWhere()) ? " and " : " where ") + userSavePoint;
         }
 
-        sql += " order by " + StringUtils.join(context.getPkColumns(), ',') + " asc";
-
-        // Using sub-query to apply rownum < readBatchSize since where has higher priority than order by
-        if (ObReaderUtils.isOracleMode(context.getCompatibleMode()) && context.getReadBatchSize() != -1) {
-            sql = String.format("select * from (%s) where rownum <= %d", sql, context.getReadBatchSize());
+        if (context.getPkColumns() != null && context.getPkColumns().length > 0) {
+            // 有主键
+            sql += " order by " + StringUtils.join(context.getPkColumns(), ',') + " asc";
         }
 
         return sql;
@@ -260,19 +266,44 @@ public class ObReaderUtils {
             sql += String.format(" partition(%s) ", context.getPartitionName());
         }
 
-        sql += " where ";
-        String append = "(" + StringUtils.join(context.getPkColumns(), ',') + ") > ("
-                + buildPlaceHolder(context.getPkColumns().length) + ")";
+        String[] pkColumns = context.getPkColumns();
+        StringBuilder whereClause = new StringBuilder();
 
-        if (StringUtils.isNotEmpty(context.getWhere())) {
-            sql += "(" + context.getWhere() + ") and ";
-        }
+        // 无论 MySQL 还是 Oracle 都统一使用 OR 条件链
+        if (pkColumns != null && pkColumns.length > 0) {
+            whereClause.append(" (");
+            for (int i = 0; i < pkColumns.length; i++) {
+                if (i == 0) {
+                    whereClause.append(pkColumns[i]).append(" > ?");
+                } else {
+                    whereClause.append(" OR (");
+                    for (int j = 0; j <= i; j++) {
+                        if (j > 0) {
+                            whereClause.append(" AND ");
+                        }
+                        if (j == i) {
+                            whereClause.append(pkColumns[j]).append(" > ? ");
+                        } else {
+                            whereClause.append(pkColumns[j]).append(" = ? ");
+                        }
+                    }
+                    whereClause.append(")");
+                }
+            }
+            whereClause.append(")");
 
-        sql = String.format("%s %s order by %s asc", sql, append, StringUtils.join(context.getPkColumns(), ','));
-
-        // Using sub-query to apply rownum < readBatchSize since where has higher priority than order by
-        if (ObReaderUtils.isOracleMode(context.getCompatibleMode()) && context.getReadBatchSize() != -1) {
-            sql = String.format("select * from (%s) where rownum <= %d", sql, context.getReadBatchSize());
+            // 如果有额外的 WHERE 条件，则拼接进去
+            if (StringUtils.isNotEmpty(context.getWhere())) {
+                whereClause.insert(0, "(" + context.getWhere() + ") AND ");
+            }
+            sql += " where " + whereClause;
+            // 添加 ORDER BY 子句
+            sql += " order by " + StringUtils.join(pkColumns, ",") + " asc";
+        } else {
+            // 无主键
+            if (StringUtils.isNotEmpty(context.getWhere())) {
+                sql += " where " + context.getWhere();
+            }
         }
 
         return sql;
@@ -476,22 +507,22 @@ public class ObReaderUtils {
             }
 
             sql = String.format(
-                "SELECT INDEX_NAME Key_name, COLUMN_NAME Column_name " +
-                    "from all_ind_columns " +
-                    "where TABLE_NAME = '%s' and TABLE_OWNER = %s " +
-                    " union all " +
-                    "SELECT DISTINCT " +
-                    "CASE " +
-                    "WHEN cons.CONSTRAINT_TYPE = 'P' THEN 'PRIMARY' " +
-                    "WHEN cons.CONSTRAINT_TYPE = 'U' THEN cons.CONSTRAINT_NAME " +
-                    "ELSE '' " +
-                    "END AS Key_name, " +
-                    "cols.column_name Column_name " +
-                    "FROM all_constraints cons, all_cons_columns cols " +
-                    "WHERE cols.table_name = '%s' AND cons.constraint_type in('P', 'U') " +
-                    "AND cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner " +
-                    "AND cons.owner = %s",
-                tableName, schema, tableName, schema);
+                    "SELECT INDEX_NAME Key_name, COLUMN_NAME Column_name " +
+                            "from all_ind_columns " +
+                            "where TABLE_NAME = '%s' and TABLE_OWNER = %s " +
+                            " union all " +
+                            "SELECT DISTINCT " +
+                            "CASE " +
+                            "WHEN cons.CONSTRAINT_TYPE = 'P' THEN 'PRIMARY' " +
+                            "WHEN cons.CONSTRAINT_TYPE = 'U' THEN cons.CONSTRAINT_NAME " +
+                            "ELSE '' " +
+                            "END AS Key_name, " +
+                            "cols.column_name Column_name " +
+                            "FROM all_constraints cons, all_cons_columns cols " +
+                            "WHERE cols.table_name = '%s' AND cons.constraint_type in('P', 'U') " +
+                            "AND cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner " +
+                            "AND cons.owner = %s",
+                    tableName, schema, tableName, schema);
         }
 
         Statement stmt = null;
@@ -530,11 +561,11 @@ public class ObReaderUtils {
                     } else {
                         // add primary key to the index if the index is not on the column
                         colsInPrimary.forEach(
-                            c -> {
-                                if (!indexColumns.contains(c)) {
-                                    indexColumns.add(c);
-                                }
-                            });
+                                c -> {
+                                    if (!indexColumns.contains(c)) {
+                                        indexColumns.add(c);
+                                    }
+                                });
                     }
                 }
             }
@@ -550,13 +581,14 @@ public class ObReaderUtils {
 
     /**
      * find out the indexes which contains all columns in where conditions
+     *
      * @param conn
      * @param table
      * @param colNamesInCondition
      * @return
      */
     private static List<String> getIndexName(Connection conn, String table,
-                                             Set<String> colNamesInCondition, String compatibleMode) {
+            Set<String> colNamesInCondition, String compatibleMode) {
         List<String> indexNames = new ArrayList<String>();
         if (colNamesInCondition == null || colNamesInCondition.size() == 0) {
             LOG.info("there is no qulified conditions in the where clause, skip index selection.");
@@ -722,8 +754,13 @@ public class ObReaderUtils {
     }
 
     public static void binding(PreparedStatement ps, List<Column> list) throws SQLException {
-        for (int i = 0, n = list.size(); i < n; i++) {
-            Column c = list.get(i);
+        if (list.isEmpty()) {
+            return;
+        }
+        List<Column> columns = buildFullParams(list);
+
+        for (int i = 0; i < columns.size(); i++) {
+            Column c = columns.get(i);
             if (c instanceof BoolColumn) {
                 ps.setLong(i + 1, ((BoolColumn) c).asLong());
             } else if (c instanceof BytesColumn) {
@@ -731,7 +768,7 @@ public class ObReaderUtils {
             } else if (c instanceof DateColumn) {
                 ps.setTimestamp(i + 1, new Timestamp(((DateColumn) c).asDate().getTime()));
             } else if (c instanceof DoubleColumn) {
-                // If the byte length is larger than the size that the double can bear, use BigDecimal to ensure accuracy
+                //应该直接使用bigDecimal，asDouble会先转换成bigDecimal再转换成Double会导致精度丢失
                 ps.setBigDecimal(i + 1, ((DoubleColumn) c).asBigDecimal());
             } else if (c instanceof LongColumn) {
                 ps.setLong(i + 1, ((LongColumn) c).asLong());
@@ -741,6 +778,21 @@ public class ObReaderUtils {
                 ps.setObject(i + 1, c.getRawData());
             }
         }
+    }
+
+    //增多检查点，上游的构建行为为A，AB，ABC，ABCD的组合，占位符的数量为n(n+1)/2，n为主键列的数量
+    public static List<Column> buildFullParams(List<Column> savePointColumns) {
+        if (savePointColumns == null || savePointColumns.isEmpty()) {
+            return new ArrayList<>();
+        }
+        int n = savePointColumns.size();
+        List<Column> fullParams = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j <= i; j++) {
+                fullParams.add(savePointColumns.get(j));
+            }
+        }
+        return fullParams;
     }
 
     public static List<Column> buildPoint(Record savePoint, int[] pkIndexs) {
@@ -809,11 +861,12 @@ public class ObReaderUtils {
 
     /**
      * compare two ob versions
+     *
      * @param version1
      * @param version2
-     * @return  0 when the two versions are the same
-     *         -1 when version1 is smaller (earlier) than version2
-     *          1 when version is bigger (later) than version2
+     * @return 0 when the two versions are the same
+     * -1 when version1 is smaller (earlier) than version2
+     * 1 when version is bigger (later) than version2
      */
     public static int compareObVersion(String version1, String version2) {
         if (version1 == null || version2 == null) {
@@ -825,7 +878,6 @@ public class ObReaderUtils {
     }
 
     /**
-     *
      * @param conn
      * @param sql
      * @return
@@ -854,6 +906,7 @@ public class ObReaderUtils {
 
     /**
      * get obversion, try ob_version first, and then try version if failed
+     *
      * @param conn
      * @return
      */

--- a/oceanbasev10reader/src/main/java/com/alibaba/datax/plugin/reader/oceanbasev10reader/util/TaskContext.java
+++ b/oceanbasev10reader/src/main/java/com/alibaba/datax/plugin/reader/oceanbasev10reader/util/TaskContext.java
@@ -80,8 +80,10 @@ public class TaskContext {
     }
 
     public String getQuerySql() {
-        if (readBatchSize == -1 || ObReaderUtils.isOracleMode(compatibleMode)) {
+        if (readBatchSize == -1) {
             return querySql;
+        } else if (ObReaderUtils.isOracleMode(compatibleMode)) {
+            return String.format("select * from (%s) where rownum <= %d", querySql, readBatchSize);
         } else {
             return querySql + " limit " + readBatchSize;
         }


### PR DESCRIPTION
[DESC]

- Add support for primary keyless tables.
- Unified management limit.
- In the case of joint primary keys, the chain call scheme of OR is used to compare the primary keys one by one to delineate the data range. For example:pk1>? or (pk1=? and pk2>?) or (pk1=? and pk2=? and pk3>?)....
- The advantages are that it supports limit, indexes, avoids data skew, and reasonably divides data ranges

Close #2311 